### PR TITLE
Arbitrary binning axes

### DIFF
--- a/sed/binning.py
+++ b/sed/binning.py
@@ -419,8 +419,9 @@ def _hist_from_bin_range(
             j = (sample[t, i] - ranges[i, 0]) * delta[i]
             is_inside = is_inside and (0 <= j < bins[i])
             flatidx += int(j) * strides[i]
+            # don't check all axes if you already know you're out of the range
             if not is_inside:
-                break  # don't check all axes if you already know you're out of the range
+                break  
         if is_inside:
             Hflat[flatidx] += int(is_inside)
 
@@ -490,12 +491,12 @@ def _hist_from_bins(
         flatidx = 0
         for i in range(ndims):
             j = binsearch(bins[i], sample[t, i])
-            is_inside = is_inside and (
-                j >= 0
-            )  # binsearch returns -1 when the value is outside the bin range
+            # binsearch returns -1 when the value is outside the bin range
+            is_inside = is_inside and (j >= 0)  
             flatidx += int(j) * strides[i]
+            # don't check all axes if you already know you're out of the range
             if not is_inside:
-                break  # don't check all axes if you already know you're out of the range
+                break  
         if is_inside:
             Hflat[flatidx] += int(is_inside)
 
@@ -507,7 +508,7 @@ def numba_histogramdd(
     bins: Union[Sequence[Union[int, np.ndarray]], np.ndarray],
     ranges: Sequence = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Wrapper for the Number pre-compiled binning functions.
+    """ Multidimensional histogramming function, powered by Numba.
 
     Behaves in total much like numpy.histogramdd. Returns uint32 arrays.
     This was chosen because it has a significant performance improvement over
@@ -554,7 +555,6 @@ def numba_histogramdd(
             method = "int"
         elif isinstance(bins[0], np.ndarray):
             method = "array"
-
     except AttributeError:
         # bins is a single integer
         bins = D * [bins]
@@ -575,7 +575,6 @@ def numba_histogramdd(
         return hist, bins
 
     elif method == "int":
-
         # normalize the range argument
         if ranges is None:
             ranges = (None,) * D

--- a/sed/binning.py
+++ b/sed/binning.py
@@ -19,10 +19,7 @@ N_CPU = psutil.cpu_count()
 
 
 def _arraysum(array_a, array_b):
-    """
-    Calculate the sum of two arrays.
-    """
-
+    """ Calculate the sum of two arrays."""
     return array_a + array_b
 
 
@@ -432,7 +429,7 @@ def _hist_from_bin_range(
 
 @numba.jit(nogil=True, parallel=False, nopython=True)
 def binsearch(bins: np.ndarray, val: float) -> int:
-    """Bisection index search function.
+    """ Bisection index search function.
 
     Finds the index of the bin with the highest value below val, i.e. the left edge.
     returns -1 when the value is outside the bin range.
@@ -488,7 +485,6 @@ def _hist_from_bins(
 
     for i in range(ndims):
         strides[i] = H.strides[i] // H.itemsize
-
     for t in range(sample.shape[0]):
         is_inside = True
         flatidx = 0

--- a/sed/binning.py
+++ b/sed/binning.py
@@ -394,7 +394,9 @@ def binsearch(bins: np.ndarray, val: float) -> int:
 
 @numba.jit(nopython=True, nogil=True, parallel=False)
 def _hist_from_bins(
-    sample: np.ndarray, bins: Sequence[np.ndarray], shape: Tuple,
+    sample: np.ndarray,
+    bins: Sequence[np.ndarray],
+    shape: Tuple,
 ) -> np.ndarray:
     """Numba powered binning method, similar to np.histogramdd.
 
@@ -500,7 +502,9 @@ def numba_histogramdd(
 
     if method == "array":
         hist = _hist_from_bins(
-            sample, tuple(bins), tuple(b.size for b in bins),
+            sample,
+            tuple(bins),
+            tuple(b.size for b in bins),
         )
         return hist, bins
 

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from sed.binning import _hist_from_bin_ranges
+from sed.binning import _hist_from_bin_ranges, _hist_from_bins
 
 sample1d = np.random.randn(int(1e2), 1)
 sample2d = np.random.randn(int(1e2), 2)
@@ -12,7 +12,9 @@ bins3d = (95, 34, 27)
 ranges1d = np.array([[1, 2]])
 ranges2d = np.array([[1, 2], [1, 2]])
 ranges3d = np.array([[1, 2], [1, 2], [1, 2]])
-
+arrays1d = np.linspace(*ranges1d[0],bins1d[0])
+arrays2d = [np.linspace(*ranges2d[i],bins2d[i]) for i in range(2)]
+arrays3d = [np.linspace(*ranges3d[i],bins3d[i]) for i in range(3)]
 
 @pytest.mark.parametrize(
     "_samples",
@@ -34,4 +36,9 @@ def test_hist_Nd_error_is_raised(_samples, _bins):
 def test_hist_Nd_proper_results():
     H1 = _hist_from_bin_ranges(sample3d, bins3d, ranges3d)
     H2, _ = np.histogramdd(sample3d, bins3d, ranges3d)
+    np.testing.assert_allclose(H1, H2)
+
+def test_from_bins_equals_from_bin_range():
+    H1 = _hist_from_bin_ranges(sample3d, bins3d, ranges3d)
+    H2 = _hist_from_bins(sample3d, arrays3d, tuple(b.size for b in arrays3d))    
     np.testing.assert_allclose(H1, H2)


### PR DESCRIPTION
Implementing binning with arbitrary axes, allowing for non-linear binnings.

It works for bin_partition, but still not for bin_dataframe.
The reason is I am trying to use nBins as either the number of bins in the old method, but also to pass it arrays directly.
This then drops the requirement of binRanges. I will try fix this....

However the numba function works as of now, even if I had to use a workaround for the creation of the target nd-array.
I always hit this problem where you cannot create tuples in Numba.

@daviddoji if you can have a look at this would be great! the tutorial notebook has tests which use this new function.

