### PR TITLE
added tutorial notebook for example dataset

### DIFF
--- a/tutorial/2 - Binning of example time-resolved ARPES data.ipynb
+++ b/tutorial/2 - Binning of example time-resolved ARPES data.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8ad4167a-e4e7-498d-909a-c04da9f177ed",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Binning example time-resolved ARPES data stored on Zenode\n",
+    "In this example, we pull some time-resolved ARPES data from Zenodo, and generate a dask dataframe using the methods of the mpes package. It requires the mpes package to be installed, in addition to the sed package.\n",
+    "For performance reasons, best store the data on a locally attached storage (no network drive)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb045e17-fa89-4c11-9d51-7f06e80d96d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from mpes import fprocessing as fp\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "sys.path.append(\"../\")\n",
+    "from sed.binning import bin_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42a6afaa-17dd-4637-ba75-a28c4ead1adf",
+   "metadata": {},
+   "source": [
+    "# Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34f46d54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataPath = '/path/to/folder' # Put in Path to a storage of at least 20 Gbyte free space.\n",
+    "! curl --output {dataPath}/WSe2.zip https://zenodo.org/record/6369728/files/WSe2.zip\n",
+    "shutil.unpack_archive(dataPath + '/WSe2.zip', extract_dir=dataPath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3be560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The Scan directory\n",
+    "fdir = dataPath + '/Scan049_1'\n",
+    "dfp = fp.dataframeProcessor(datafolder=fdir)\n",
+    "dfp.read(source='folder', ftype='h5')\n",
+    "ddf=dfp.edf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6902fd56-1456-4da6-83a4-0f3f6b831eb6",
+   "metadata": {},
+   "source": [
+    "# Define the binning range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7601cd7-cd51-40a9-8fc7-8b7d32ff15d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binAxes = [\"X\", \"Y\", \"t\"]\n",
+    "nBins = [120, 120, 120]\n",
+    "binRanges = [(0, 1500), (0, 1500), (65000, 67000)]\n",
+    "coords = {ax: np.linspace(r[0], r[1], n) for ax, r, n in zip(binAxes, binRanges, nBins)}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba0416b3-b4b6-4b18-8ed3-a76ab4889892",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ddf.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01066d40-010a-490b-9033-7339e5a21b26",
+   "metadata": {},
+   "source": [
+    "# compute distributed binning on the partitioned dask dataframe\n",
+    "We generated 100 dataframe partiions from the 100 files in the dataset, which we will bin parallelly with the dataframe binning function into a 3D grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbed3261-187c-498d-8ee0-0c3a3c8a8c1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "res = bin_dataframe(\n",
+    "    ddf,\n",
+    "    binAxes=binAxes,\n",
+    "    binRanges=binRanges,\n",
+    "    nBins=nBins,\n",
+    "    hist_mode=\"numba\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99d7d136-b677-4c16-bc8f-31ba8216579c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 3, figsize=(8, 2.5), constrained_layout=True)\n",
+    "for dim, ax in zip(binAxes, axs):\n",
+    "    res.sum(dim).plot(ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a3eaf0e",
+   "metadata": {},
+   "source": [
+    "# Compare to MPES binning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8adf386-669f-4b77-920f-6dfec7b637c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dfp.distributedBinning(axes=binAxes, nbins=nBins, ranges=binRanges, scheduler='threads', ret=False, jittered=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6665dc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(res.data==dfp.histdict['binned']).all()"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "728003ee06929e5fa5ff815d1b96bf487266025e4b7440930c6bf4536d02d243"
+  },
+  "kernelspec": {
+   "display_name": "sed_poetry",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I added a notebook with test data on zenodo, please have a look. 
It requires the mpes package to generate the dataframe, and at the moment the version that is packaged cannot be installed together with sed (it pins h5py). I made a fork that does not do this at https://github.com/rettigl/mpes
Not sure if we should reflect this in the dependencies.
I intend to include this into the main mpes package, and maybe also make a new pypi package, but I don't really know how to do that.
I also did not thest with the new binning branch