### PR TITLE
Binning with jitter on machine coordinates

### DIFF
--- a/sed/core.py
+++ b/sed/core.py
@@ -1,19 +1,18 @@
-from typing import Any
 from pathlib import Path
-from typing import Union
-from typing import Tuple
-from typing import Sequence
+from typing import Any
 from typing import List
+from typing import Sequence
+from typing import Tuple
+from typing import Union
 
 import numpy as np
 import pandas as pd
 import psutil
 import xarray as xr
-import dask
 
-from .metadata import MetaHandler
-from .dfops import apply_jitter
 from .binning import bin_dataframe
+from .dfops import apply_jitter
+from .metadata import MetaHandler
 
 N_CPU = psutil.cpu_count()
 
@@ -21,14 +20,19 @@ N_CPU = psutil.cpu_count()
 class SedProcessor:
     """[summary]"""
 
-    def __init__(self, df: pd.DataFrame = None, metadata: dict = {}, config: Union[dict, Path, str] = {}):
+    def __init__(
+        self,
+        df: pd.DataFrame = None,
+        metadata: dict = {},
+        config: Union[dict, Path, str] = {},
+    ):
 
         # TODO: handle/load config dict/file
         self._config = config
         if not isinstance(self._config, dict):
             self._config = {}
-        if 'num_cores' not in self._config.keys():
-            self._config['num_cores'] = N_CPU-1
+        if "num_cores" not in self._config.keys():
+            self._config["num_cores"] = N_CPU - 1
 
         self._dataframe = df
         self._dataframe_jittered = None
@@ -94,32 +98,38 @@ class SedProcessor:
         self._dataframe = pd.DataFrame(data)
 
     def gen_jittered_df(self, cols: Sequence[str] = None) -> None:
-        """Generate a a second dataframe, where the selected dataframe columes have jitter applied
+        """Generate a a second dataframe, where the selected dataframe
+         columns have jitter applied
 
         Args:
-            cols: the colums onto which to apply jitter. If omitted, the comlums are taken from the config.
+            cols: the colums onto which to apply jitter. If omitted,
+            the comlums are taken from the config.
 
         Returns:
             None
         """
         if cols is None:
-            try: 
-                cols = self._config['jitter_cols']
+            try:
+                cols = self._config["jitter_cols"]
             except KeyError:
-                cols = self._dataframe.columns #jitter all columns
-            
-        self._dataframe_jittered = self._dataframe.map_partitions(apply_jitter, cols=cols, cols_jittered=cols)
+                cols = self._dataframe.columns  # jitter all columns
 
+        self._dataframe_jittered = self._dataframe.map_partitions(
+            apply_jitter,
+            cols=cols,
+            cols_jittered=cols,
+        )
 
     def compute(
         self,
         bins: Union[
-        int,
-        dict,
-        tuple,
-        List[int],
-        List[np.ndarray],
-        List[tuple],] = 100,
+            int,
+            dict,
+            tuple,
+            List[int],
+            List[np.ndarray],
+            List[tuple],
+        ] = 100,
         axes: Union[str, Sequence[str]] = None,
         ranges: Sequence[Tuple[float, float]] = None,
         histMode: str = "numba",
@@ -147,20 +157,36 @@ class SedProcessor:
         Returns:
             [description]
         """
-        assert self._dataframe is not None, 'dataframe needs to be loaded first!'
+        assert (
+            self._dataframe is not None
+        ), "dataframe needs to be loaded first!"
 
         if nCores is None:
-            nCores = self._config['num_cores']
+            nCores = self._config["num_cores"]
 
         df = self._dataframe
 
         if jittered:
-            assert self._dataframe_jittered is not None, 'jittered dataframe needs to be generated first, use SedProcessor.gen_jittered_df()!'
+            assert self._dataframe_jittered is not None, (
+                "jittered dataframe needs to be generated first, "
+                "use SedProcessor.gen_jittered_df(cols)!"
+            )
             df = self._dataframe_jittered
-        
-        self._binned = bin_dataframe(df=df, bins=bins, axes=axes, ranges=ranges, histMode=histMode, mode=mode, pbar=pbar, nCores=nCores, nThreadsPerWorker=nThreadsPerWorker, threadpoolAPI=threadpoolAPI, **kwds)
-        return self._binned
 
+        self._binned = bin_dataframe(
+            df=df,
+            bins=bins,
+            axes=axes,
+            ranges=ranges,
+            histMode=histMode,
+            mode=mode,
+            pbar=pbar,
+            nCores=nCores,
+            nThreadsPerWorker=nThreadsPerWorker,
+            threadpoolAPI=threadpoolAPI,
+            **kwds,
+        )
+        return self._binned
 
     def add_dimension(self, name, range):
         if name in self._coordinates:

--- a/sed/core.py
+++ b/sed/core.py
@@ -31,8 +31,18 @@ class SedProcessor:
         self._config = config
         if not isinstance(self._config, dict):
             self._config = {}
+        if "hist_mode" not in self._config.keys():
+            self._config["hist_mode"] = "numba"
+        if "mode" not in self._config.keys():
+            self._config["mode"] = "fast"
+        if "pbar" not in self._config.keys():
+            self._config["pbar"] = True
         if "num_cores" not in self._config.keys():
             self._config["num_cores"] = N_CPU - 1
+        if "threads_per_worker" not in self._config.keys():
+            self._config["threads_per_worker"] = 4
+        if "threadpool_API" not in self._config.keys():
+            self._config["threadpool_API"] = "blas"
 
         self._dataframe = df
         self._dataframe_jittered = None
@@ -97,9 +107,9 @@ class SedProcessor:
         """
         self._dataframe = pd.DataFrame(data)
 
-    def gen_jittered_df(self, cols: Sequence[str] = None) -> None:
-        """Generate a a second dataframe, where the selected dataframe
-         columns have jitter applied
+    def add_jitter(self, cols: Sequence[str] = None) -> None:
+        """Add jitter to the selected dataframe columns.
+
 
         Args:
             cols: the colums onto which to apply jitter. If omitted,
@@ -114,7 +124,7 @@ class SedProcessor:
             except KeyError:
                 cols = self._dataframe.columns  # jitter all columns
 
-        self._dataframe_jittered = self._dataframe.map_partitions(
+        self._dataframe = self._dataframe.map_partitions(
             apply_jitter,
             cols=cols,
             cols_jittered=cols,
@@ -132,58 +142,61 @@ class SedProcessor:
         ] = 100,
         axes: Union[str, Sequence[str]] = None,
         ranges: Sequence[Tuple[float, float]] = None,
-        histMode: str = "numba",
-        mode: str = "fast",
-        jittered: bool = True,
-        pbar: bool = True,
-        nCores: int = None,
-        nThreadsPerWorker: int = 4,
-        threadpoolAPI: str = "blas",
         **kwds,
     ) -> xr.DataArray:
         """Compute the histogram along the given dimensions.
 
         Args:
-            mode: Binning method, choose between numba,
-                fast, lean and legacy (Y. Acremann's method).
-            ncores: [description].
-            axes: [description].
-            nbins: [description].
-            ranges: [description].
-            pbar: [description].
-            jittered: [description].
-            pbenv: [description].
+            bins: Definition of the bins. Can  be any of the following cases:
+                - an integer describing the number of bins in on all dimensions
+                - a tuple of 3 numbers describing start, end and step of the binning
+                  range
+                - a np.arrays defining the binning edges
+                - a list (NOT a tuple) of any of the above (int, tuple or np.ndarray)
+                - a dictionary made of the axes as keys and any of the above as values.
+                This takes priority over the axes and range arguments.
+            axes: The names of the axes (columns) on which to calculate the histogram.
+                The order will be the order of the dimensions in the resulting array.
+            ranges: list of tuples containing the start and end point of the binning
+                    range.
+            kwds: Keywords argument passed to bin_dataframe.
+
+        Raises:
+            AssertError: Rises when no dataframe has been loaded.
 
         Returns:
-            [description]
+            The result of the n-dimensional binning represented in an
+                xarray object, combining the data with the axes.
         """
+
         assert (
             self._dataframe is not None
         ), "dataframe needs to be loaded first!"
 
-        if nCores is None:
-            nCores = self._config["num_cores"]
-
-        df = self._dataframe
-
-        if jittered:
-            assert self._dataframe_jittered is not None, (
-                "jittered dataframe needs to be generated first, "
-                "use SedProcessor.gen_jittered_df(cols)!"
-            )
-            df = self._dataframe_jittered
+        hist_mode = kwds.pop("hist_mode", self._config["hist_mode"])
+        mode = kwds.pop("mode", self._config["mode"])
+        pbar = kwds.pop("pbar", self._config["pbar"])
+        num_cores = kwds.pop("num_cores", self._config["num_cores"])
+        threads_per_worker = kwds.pop(
+            "threads_per_worker",
+            self._config["threads_per_worker"],
+        )
+        threadpool_API = kwds.pop(
+            "threadpool_API",
+            self._config["threadpool_API"],
+        )
 
         self._binned = bin_dataframe(
-            df=df,
+            df=self._dataframe,
             bins=bins,
             axes=axes,
             ranges=ranges,
-            histMode=histMode,
+            histMode=hist_mode,
             mode=mode,
             pbar=pbar,
-            nCores=nCores,
-            nThreadsPerWorker=nThreadsPerWorker,
-            threadpoolAPI=threadpoolAPI,
+            nCores=num_cores,
+            nThreadsPerWorker=threads_per_worker,
+            threadpoolAPI=threadpool_API,
             **kwds,
         )
         return self._binned

--- a/sed/core.py
+++ b/sed/core.py
@@ -5,6 +5,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
+import dask.dataframe
 import numpy as np
 import pandas as pd
 import psutil
@@ -22,7 +23,7 @@ class SedProcessor:
 
     def __init__(
         self,
-        df: pd.DataFrame = None,
+        df: Union[pd.DataFrame, dask.dataframe.DataFrame] = None,
         metadata: dict = {},
         config: Union[dict, Path, str] = {},
     ):
@@ -95,7 +96,10 @@ class SedProcessor:
         for k, v in coords.items():
             self._coordinates[k] = xr.DataArray(v)
 
-    def load(self, data: pd.DataFrame) -> None:
+    def load(
+        self,
+        data: Union[pd.DataFrame, dask.dataframe.DataFrame],
+    ) -> None:
         """Load tabular data of Single Events
 
         Args:
@@ -105,7 +109,7 @@ class SedProcessor:
         Returns:
             None
         """
-        self._dataframe = pd.DataFrame(data)
+        self._dataframe = data
 
     def add_jitter(self, cols: Sequence[str] = None) -> None:
         """Add jitter to the selected dataframe columns.

--- a/sed/core.py
+++ b/sed/core.py
@@ -1,10 +1,19 @@
 from typing import Any
+from pathlib import Path
+from typing import Union
+from typing import Tuple
+from typing import Sequence
+from typing import List
 
+import numpy as np
 import pandas as pd
 import psutil
 import xarray as xr
+import dask
 
 from .metadata import MetaHandler
+from .dfops import apply_jitter
+from .binning import bin_dataframe
 
 N_CPU = psutil.cpu_count()
 
@@ -12,13 +21,21 @@ N_CPU = psutil.cpu_count()
 class SedProcessor:
     """[summary]"""
 
-    def __init__(self):
+    def __init__(self, df: pd.DataFrame = None, metadata: dict = {}, config: Union[dict, Path, str] = {}):
 
-        self._dataframe = None
+        # TODO: handle/load config dict/file
+        self._config = config
+        if not isinstance(self._config, dict):
+            self._config = {}
+        if 'num_cores' not in self._config.keys():
+            self._config['num_cores'] = N_CPU-1
+
+        self._dataframe = df
+        self._dataframe_jittered = None
 
         self._dimensions = []
         self._coordinates = {}
-        self._attributes = MetaHandler()
+        self._attributes = MetaHandler(meta=metadata)
 
     def __repr__(self):
         if self._dataframe is None:
@@ -76,17 +93,42 @@ class SedProcessor:
         """
         self._dataframe = pd.DataFrame(data)
 
+    def gen_jittered_df(self, cols: Sequence[str] = None) -> None:
+        """Generate a a second dataframe, where the selected dataframe columes have jitter applied
+
+        Args:
+            cols: the colums onto which to apply jitter. If omitted, the comlums are taken from the config.
+
+        Returns:
+            None
+        """
+        if cols is None:
+            try: 
+                cols = self._config['jitter_cols']
+            except KeyError:
+                cols = self._dataframe.columns #jitter all columns
+            
+        self._dataframe_jittered = self._dataframe.map_partitions(apply_jitter, cols=cols, cols_jittered=cols)
+
+
     def compute(
         self,
-        mode: str = "numba",
-        binDict: dict = None,
-        axes: list = None,
-        nbins: int = None,
-        ranges: list = None,
-        pbar: bool = True,
+        bins: Union[
+        int,
+        dict,
+        tuple,
+        List[int],
+        List[np.ndarray],
+        List[tuple],] = 100,
+        axes: Union[str, Sequence[str]] = None,
+        ranges: Sequence[Tuple[float, float]] = None,
+        histMode: str = "numba",
+        mode: str = "fast",
         jittered: bool = True,
-        ncores: int = N_CPU,
-        pbenv: str = "classic",
+        pbar: bool = True,
+        nCores: int = None,
+        nThreadsPerWorker: int = 4,
+        threadpoolAPI: str = "blas",
         **kwds,
     ) -> xr.DataArray:
         """Compute the histogram along the given dimensions.
@@ -98,7 +140,6 @@ class SedProcessor:
             axes: [description].
             nbins: [description].
             ranges: [description].
-            binDict: [description].
             pbar: [description].
             jittered: [description].
             pbenv: [description].
@@ -106,7 +147,20 @@ class SedProcessor:
         Returns:
             [description]
         """
-        pass
+        assert self._dataframe is not None, 'dataframe needs to be loaded first!'
+
+        if nCores is None:
+            nCores = self._config['num_cores']
+
+        df = self._dataframe
+
+        if jittered:
+            assert self._dataframe_jittered is not None, 'jittered dataframe needs to be generated first, use SedProcessor.gen_jittered_df()!'
+            df = self._dataframe_jittered
+        
+        self._binned = bin_dataframe(df=df, bins=bins, axes=axes, ranges=ranges, histMode=histMode, mode=mode, pbar=pbar, nCores=nCores, nThreadsPerWorker=nThreadsPerWorker, threadpoolAPI=threadpoolAPI, **kwds)
+        return self._binned
+
 
     def add_dimension(self, name, range):
         if name in self._coordinates:

--- a/sed/dfops.py
+++ b/sed/dfops.py
@@ -1,29 +1,27 @@
-# Note: some of the functions presented here were 
+# Note: some of the functions presented here were
 # inspired by https://github.com/mpes-kit/mpes
-import numpy as np
-import dask
-from typing import List
 from typing import Sequence
-from typing import Tuple
 from typing import Union
 
-
+import dask
+import numpy as np
 
 
 def apply_jitter(
-    df: dask.dataframe.core.DataFrame, 
-    cols: Union[str, Sequence[str]], 
-    cols_jittered: Union[str, Sequence[str]] = None, 
-    amps: Union[float, Sequence[float]] = 0.5, 
-    type: str = 'uniform',
+    df: dask.dataframe.core.DataFrame,
+    cols: Union[str, Sequence[str]],
+    cols_jittered: Union[str, Sequence[str]] = None,
+    amps: Union[float, Sequence[float]] = 0.5,
+    type: str = "uniform",
 ) -> dask.dataframe.core.DataFrame:
-    """ Add jittering to one or more dataframe columns.
+    """Add jittering to one or more dataframe columns.
 
     :Parameters:
         df : dataframe
             Dataframe to add noise/jittering to.
-        amps : numer or list of numbers 
-            Amplitude scalings for the jittering noise. If one number is given, the same is used for all axes
+        amps : numer or list of numbers
+            Amplitude scalings for the jittering noise. If one number is given,
+            the same is used for all axes
         cols : str list
             Names of the columns to add jittering to.
         cols_jittered : str list
@@ -32,26 +30,30 @@ def apply_jitter(
     :Return:
         dataframe with added columns
     """
-    assert cols!=None, 'cols needs to be provided!'
-    assert type in ('uniform', 'normal'), 'type needs to be one of \'normal\', \'uniform\'!'
-    
+    assert cols is not None, "cols needs to be provided!"
+    assert type in (
+        "uniform",
+        "normal",
+    ), "type needs to be one of 'normal', 'uniform'!"
+
     if isinstance(cols, str):
         cols = [cols]
     if isinstance(cols_jittered, str):
         cols_jittered = [cols_jittered]
-    if cols_jittered == None:
+    if cols_jittered is None:
         cols_jittered = [col + "_jittered" for col in cols]
     if isinstance(amps, float):
-        amps = np.ones(len(cols))*amps
+        amps = np.ones(len(cols)) * amps
 
     colsize = df[cols[0]].size
 
-    if (type == 'uniform'):
+    if type == "uniform":
         # Uniform Jitter distribution
-        jitter =  np.random.uniform(low=-1, high=1, size=colsize)
-    elif (type == 'normal'):
-        # Normal Jitter distribution works better for non-linear transformations and jitter sizes that don't match the original bin sizes
-        jitter =  np.random.standard_normal(size=colsize)
+        jitter = np.random.uniform(low=-1, high=1, size=colsize)
+    elif type == "normal":
+        # Normal Jitter distribution works better for non-linear transformations and
+        # jitter sizes that don't match the original bin sizes
+        jitter = np.random.standard_normal(size=colsize)
 
     for (col, col_jittered, amp) in zip(cols, cols_jittered, amps):
         df[col_jittered] = df[col] + amp * jitter

--- a/sed/dfops.py
+++ b/sed/dfops.py
@@ -1,0 +1,59 @@
+# Note: some of the functions presented here were 
+# inspired by https://github.com/mpes-kit/mpes
+import numpy as np
+import dask
+from typing import List
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+
+
+
+
+def apply_jitter(
+    df: dask.dataframe.core.DataFrame, 
+    cols: Union[str, Sequence[str]], 
+    cols_jittered: Union[str, Sequence[str]] = None, 
+    amps: Union[float, Sequence[float]] = 0.5, 
+    type: str = 'uniform',
+) -> dask.dataframe.core.DataFrame:
+    """ Add jittering to one or more dataframe columns.
+
+    :Parameters:
+        df : dataframe
+            Dataframe to add noise/jittering to.
+        amps : numer or list of numbers 
+            Amplitude scalings for the jittering noise. If one number is given, the same is used for all axes
+        cols : str list
+            Names of the columns to add jittering to.
+        cols_jittered : str list
+            Names of the columns with added jitter.
+        type: the type of jitter to add. 'uniform' or 'normal' distributed noise.
+    :Return:
+        dataframe with added columns
+    """
+    assert cols!=None, 'cols needs to be provided!'
+    assert type in ('uniform', 'normal'), 'type needs to be one of \'normal\', \'uniform\'!'
+    
+    if isinstance(cols, str):
+        cols = [cols]
+    if isinstance(cols_jittered, str):
+        cols_jittered = [cols_jittered]
+    if cols_jittered == None:
+        cols_jittered = [col + "_jittered" for col in cols]
+    if isinstance(amps, float):
+        amps = np.ones(len(cols))*amps
+
+    colsize = df[cols[0]].size
+
+    if (type == 'uniform'):
+        # Uniform Jitter distribution
+        jitter =  np.random.uniform(low=-1, high=1, size=colsize)
+    elif (type == 'normal'):
+        # Normal Jitter distribution works better for non-linear transformations and jitter sizes that don't match the original bin sizes
+        jitter =  np.random.standard_normal(size=colsize)
+
+    for (col, col_jittered, amp) in zip(cols, cols_jittered, amps):
+        df[col_jittered] = df[col] + amp * jitter
+
+    return df

--- a/sed/dfops.py
+++ b/sed/dfops.py
@@ -3,17 +3,18 @@
 from typing import Sequence
 from typing import Union
 
+import dask.dataframe
 import numpy as np
 import pandas as pd
 
 
 def apply_jitter(
-    df: pd.DataFrame,
+    df: Union[pd.DataFrame, dask.dataframe.DataFrame],
     cols: Union[str, Sequence[str]],
     cols_jittered: Union[str, Sequence[str]] = None,
     amps: Union[float, Sequence[float]] = 0.5,
     type: str = "uniform",
-) -> pd.DataFrame:
+) -> Union[pd.DataFrame, dask.dataframe.DataFrame]:
     """Add jittering to one or more dataframe columns.
 
     :Parameters:

--- a/sed/dfops.py
+++ b/sed/dfops.py
@@ -3,8 +3,8 @@
 from typing import Sequence
 from typing import Union
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 
 def apply_jitter(
@@ -13,7 +13,7 @@ def apply_jitter(
     cols_jittered: Union[str, Sequence[str]] = None,
     amps: Union[float, Sequence[float]] = 0.5,
     type: str = "uniform",
-) -> dask.dataframe.core.DataFrame:
+) -> pd.DataFrame:
     """Add jittering to one or more dataframe columns.
 
     :Parameters:

--- a/sed/dfops.py
+++ b/sed/dfops.py
@@ -3,12 +3,12 @@
 from typing import Sequence
 from typing import Union
 
-import dask
+import pandas as pd
 import numpy as np
 
 
 def apply_jitter(
-    df: dask.dataframe.core.DataFrame,
+    df: pd.DataFrame,
     cols: Union[str, Sequence[str]],
     cols_jittered: Union[str, Sequence[str]] = None,
     amps: Union[float, Sequence[float]] = 0.5,

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from sed.binning import _hist_from_bin_ranges, _hist_from_bins
+from sed.binning import _hist_from_bin_range, _hist_from_bins
 
 sample1d = np.random.randn(int(1e2), 1)
 sample2d = np.random.randn(int(1e2), 2)
@@ -30,15 +30,15 @@ def test_hist_Nd_error_is_raised(_samples, _bins):
     with pytest.raises(ValueError):
         if _samples.shape[1] == len(_bins):
             pytest.skip("Not of interest")
-        _hist_from_bin_ranges(_samples, _bins, ranges1d)
+        _hist_from_bin_range(_samples, _bins, ranges1d)
 
 
 def test_hist_Nd_proper_results():
-    H1 = _hist_from_bin_ranges(sample3d, bins3d, ranges3d)
+    H1 = _hist_from_bin_range(sample3d, bins3d, ranges3d)
     H2, _ = np.histogramdd(sample3d, bins3d, ranges3d)
     np.testing.assert_allclose(H1, H2)
 
 def test_from_bins_equals_from_bin_range():
-    H1 = _hist_from_bin_ranges(sample3d, bins3d, ranges3d)
+    H1 = _hist_from_bin_range(sample3d, bins3d, ranges3d)
     H2 = _hist_from_bins(sample3d, arrays3d, tuple(b.size for b in arrays3d))    
     np.testing.assert_allclose(H1, H2)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from sed.binning import _hist_from_bin_range, _hist_from_bins
+from sed.binning import _hist_from_bin_range
+from sed.binning import _hist_from_bins
 
 sample1d = np.random.randn(int(1e2), 1)
 sample2d = np.random.randn(int(1e2), 2)
@@ -12,9 +13,10 @@ bins3d = (95, 34, 27)
 ranges1d = np.array([[1, 2]])
 ranges2d = np.array([[1, 2], [1, 2]])
 ranges3d = np.array([[1, 2], [1, 2], [1, 2]])
-arrays1d = np.linspace(*ranges1d[0],bins1d[0])
-arrays2d = [np.linspace(*ranges2d[i],bins2d[i]) for i in range(2)]
-arrays3d = [np.linspace(*ranges3d[i],bins3d[i]) for i in range(3)]
+arrays1d = np.linspace(*ranges1d[0], bins1d[0])
+arrays2d = [np.linspace(*ranges2d[i], bins2d[i]) for i in range(2)]
+arrays3d = [np.linspace(*ranges3d[i], bins3d[i]) for i in range(3)]
+
 
 @pytest.mark.parametrize(
     "_samples",
@@ -38,7 +40,8 @@ def test_hist_Nd_proper_results():
     H2, _ = np.histogramdd(sample3d, bins3d, ranges3d)
     np.testing.assert_allclose(H1, H2)
 
+
 def test_from_bins_equals_from_bin_range():
     H1 = _hist_from_bin_range(sample3d, bins3d, ranges3d)
-    H2 = _hist_from_bins(sample3d, arrays3d, tuple(b.size for b in arrays3d))    
+    H2 = _hist_from_bins(sample3d, arrays3d, tuple(b.size for b in arrays3d))
     np.testing.assert_allclose(H1, H2)

--- a/tests/test_dfops.py
+++ b/tests/test_dfops.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pandas as pd
+
+from sed.dfops import apply_jitter
+
+n_pts = 100
+cols = ["posx", "posy", "energy"]
+df = pd.DataFrame(np.random.randn(n_pts, len(cols)), columns=cols)
+
+def test_apply_jitter():
+    cols_jittered = [col + '_jittered' for col in cols]
+    df_jittered = apply_jitter(df, cols=cols, cols_jittered=cols_jittered)
+    assert isinstance(df_jittered, pd.DataFrame)
+    for col in cols_jittered:
+        assert col in df_jittered.columns

--- a/tests/test_dfops.py
+++ b/tests/test_dfops.py
@@ -7,8 +7,9 @@ n_pts = 100
 cols = ["posx", "posy", "energy"]
 df = pd.DataFrame(np.random.randn(n_pts, len(cols)), columns=cols)
 
+
 def test_apply_jitter():
-    cols_jittered = [col + '_jittered' for col in cols]
+    cols_jittered = [col + "_jittered" for col in cols]
     df_jittered = apply_jitter(df, cols=cols, cols_jittered=cols_jittered)
     assert isinstance(df_jittered, pd.DataFrame)
     for col in cols_jittered:


### PR DESCRIPTION
This pull request implements jittering on the intrinsic machine coordinates within the wrapper class by introducing a copy of the dataframe with jittering applied to the relevant coordinates. The idea would be to do this step in the beginning, and apply all following dataframe operations on both dataframes. Then, at the binning step, by choosing either dataframe, one can still choose between jitter or no jitter. Only downside is that this will be an all or nothing choice, depending on which axes one chose to be jitterd in the beginning.
The changes also include a first working version of binning in the wrapper class.