### PR TITLE
Histograms from timestamps

### DIFF
--- a/tutorial/3 - Conversion Pipeline for example time-resolved ARPES data.ipynb
+++ b/tutorial/3 - Conversion Pipeline for example time-resolved ARPES data.ipynb
@@ -64,7 +64,7 @@
     "# The Scan directory\n",
     "fdir = data_path + '/Scan049_1'\n",
     "# create sed processor using the config file:\n",
-    "sp = sed.SedProcessor(folder=fdir, config=\"../tests/data/config/config.yaml\")"
+    "sp = sed.SedProcessor(folder=fdir, config=\"../tests/data/config/config.yaml\", time_stamps=True)"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "# The time elapsed in the scan\n",
-    "sp.loader.get_elapsed_time()"
+    "sp.loader.get_elapsed_time(fids=[1])"
    ]
   },
   {
@@ -483,7 +483,7 @@
     "axes = ['kx', 'ky', 'energy', 'delay']\n",
     "bins = [100, 100, 200, 50]\n",
     "ranges = [[-2, 2], [-2, 2], [-4, 2], [-600, 1600]]\n",
-    "res = sp.compute(bins=bins, axes=axes, ranges=ranges)"
+    "res = sp.compute(bins=bins, axes=axes, ranges=ranges, df_partitions=10)"
    ]
   },
   {
@@ -512,7 +512,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3073b9ba",
+   "id": "645c0e08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram = sp.get_normalization_histogram(df_partitions=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dea7dd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax, fig = plt.subplots(1,1)\n",
+    "plt.plot(histogram)\n",
+    "plt.plot(sp._binned.sum(axis=(0,1,2))/90000)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7a9d91f",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This adds histogram calculation based on the timeStamp column in the dataframe

Histogram calculation in the example notebook takes on our machine close to 2 minutes. Additionally, binning becomes slower when timeStamps are generated, even if they are not used during binning.