### PR TITLE
simplify NaN filling in FlashLoader and make it lazy

### DIFF
--- a/sed/core/preprocessing.py
+++ b/sed/core/preprocessing.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from typing import Sequence, Iterator
+import inspect
+from copy import deepcopy
+
+import json
+from dask import dataframe as ddf
+import pandas as pd
+from .metadata import MetaHandler
+
+
+def as_pre_processing(func):
+    """Decorator to create a PreProcessingStep from a function
+
+    Args:
+        func: the function to decorate
+
+    Returns:
+        a PreProcessingStep instance
+    """
+    signature = inspect.signature(func)  # get the signature of the function
+    parameters = signature.parameters
+    # create a dictionary with the default values of the parameters
+    defaults = {
+        param.name: param.default
+        for param in parameters.values()
+        if param.default is not inspect.Parameter.empty
+    }
+    def wrapper(*args, **kwargs):
+        kwargs.update(defaults)
+        return PreProcessingStep(func, *args, **kwargs)
+    return wrapper
+
+
+class PreProcessingStep:
+    """PreProcessing step class which allows mapping a function to a dataframe
+
+    Args:
+        func: the function to map to the dataframe
+        *args: the arguments of the function
+        **kwargs: the keyword arguments of the function
+    
+    Attributes:
+        func: the function to map to the dataframe
+        args: the arguments of the function
+        kwargs: the keyword arguments of the function
+        df: the dataframe to apply the function to
+        duplicate_policy: the policy to use when logging the function call to the metadata
+    """
+
+    def __init__(self, func, *args, **kwargs) -> None:
+        self.func = func
+        self.args = args
+        self.df = kwargs.pop("df", None)
+        self.kwargs = kwargs
+        self.__doc__ = f"PreProcessing step class which allows mapping the " \
+            f"function:\n\n{func.__name__} docstring:\n{func.__doc__}"
+        self.duplicate_policy = kwargs.pop("duplicate_policy", "raise")
+        self.name = kwargs.pop("name", func.__name__)
+
+    def log_metadata(self, meta:MetaHandler) -> None:
+        """ log the call of the function to the meta dictionary """
+        meta.add(self.to_dict(), self.name, self.duplicate_policy)
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the object"""
+        return {"func": self.func, "args": self.args, "kwargs": self.kwargs}
+
+    def to_json(self) -> str:
+        """Return a json representation of the object"""
+        return json.dumps(self.to_dict())
+
+    def __call__(self, df=None, metadata:MetaHandler=None) -> ddf.DataFrame:
+        """Apply the function to the dataframe by calling it directly"""
+        df = self._get_df(df)
+        if metadata is not None:
+            self.log_metadata(metadata)
+        return self.func(df=df, *self.args, **self.kwargs)
+
+    def map(self, df=None, metadata:MetaHandler=None) -> ddf.DataFrame:
+        """Apply the function to the dataframe using map_partitions"""
+        df = self._get_df(df)
+        if metadata is not None:
+            self.log_metadata(metadata)
+        # try:
+
+            meta = self(df.head()).dtypes.to_dict()
+            # Create the _meta information for Dask DataFrame
+            # meta = 
+        df = df.map_partitions(
+            self.func, 
+            *self.args, 
+            **self.kwargs, 
+            meta=meta)
+        # except TypeError:
+        #     out = df.map_partitions(self.func, *self.args, **self.kwargs)
+        return df
+
+    def _get_df(self, df=None) -> ddf.DataFrame:
+        """Get the dataframe to apply the function to"""
+        if df is None:
+            df = self.df
+        if df is None:
+            raise ValueError("No dataframe provided")
+        return df
+
+    def __repr__(self) -> str:
+        """Return the string representation of the object"""
+        return f"{self.__class__.__name__}({self.func.__name__})"
+
+    def __str__(self) -> str:
+        """Return the string representation of the object"""
+        s = f"{self.__class__.__name__}({self.func.__name__})"
+        s += f"\n - args: {self.args}"
+        s += f"\n - kwargs: {self.kwargs}"
+        return s
+
+    def _repr_html_(self) -> str:
+        """Return the html representation of the object"""
+        s = f"<h3>{self.__class__.__name__}({self.func.__name__})</h3>"
+        s += f"<p>args: {self.args}</p>"
+        s += f"<p>kwargs: {self.kwargs}</p>"
+        return s
+
+    def __eq__(self, __value: object) -> bool:
+        """Check if two PreProcessingStep objects are equal"""
+        return self.__dict__ == __value.__dict__
+
+    def __hash__(self) -> int:
+        """Return the hash of the object"""
+        return hash(self.__dict__)
+
+    def __copy__(self) -> PreProcessingStep:
+        """Return a shallow copy of the object"""
+        return PreProcessingStep(self.func, *self.args, **self.kwargs)
+
+    def __deepcopy__(self) -> PreProcessingStep:
+        """Return a deep copy of the object"""
+        return PreProcessingStep(
+            self.func, *deepcopy(self.args), **deepcopy(self.kwargs)
+        )
+
+    def __add__(self, other) -> PreProcessingPipeline:
+        """Add two PreProcessingStep objects"""
+        return PreProcessingPipeline([self, other])
+
+    def __radd__(self, other) -> PreProcessingPipeline:
+        """Add two PreProcessingStep objects"""
+        return PreProcessingPipeline([other, self])
+
+
+class PreProcessingPipeline:
+    """ Allows sequentially mapping functions to a dataframe
+
+    TODOs:  - add a method to test the pipeline by applying it to the head of the df
+            - add a method to visualize the pipeline
+            - add a method to visualize the pipeline as a graph
+            - add a method to visualize the pipeline as a table
+
+    Args:
+        steps: the steps of the pipeline
+    """
+
+    def __init__(self, steps: Sequence[PreProcessingStep]) -> None:
+        if isinstance(steps, Sequence):
+            self.steps = steps
+        else:
+            self.steps = [steps]
+
+    @classmethod
+    def from_dict(cls, d: dict) -> PreProcessingPipeline:
+        """Create a PreProcessingPipeline object from a dictionary"""
+        steps = [PreProcessingStep(**step) for step in d["pre_processing"]]
+        return cls(steps)
+
+    @classmethod
+    def from_json(cls, s: str) -> PreProcessingPipeline:
+        """Create a PreProcessingPipeline object from a json string"""
+        d = json.loads(s)
+        return cls.from_dict(d)
+
+    def test(self, df=None):
+        """Test the pipeline by applying it to the head of the dataframe
+
+        Args:
+            df: the dataframe to apply the pipeline to
+
+        Returns:
+            a dictionary with the report of the test
+        """
+        df = df or self.df
+        dfh = df.head()
+        report = {}
+        for step in self.steps:
+            try:
+                df = step(df)
+                report[step.func.__name__] = "passed"
+            except Exception as e:
+                report[step.func.__name__] = e
+        return report
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the object"""
+        return {"pre_processing": [step.to_dict() for step in self.steps]}
+
+    def to_json(self) -> str:
+        """Return a json representation of the object"""
+        return json.dumps(self.to_dict())
+
+    def append(self, step: PreProcessingStep) -> None:
+        """Append a step to the pipeline"""
+        self.steps.append(step)
+
+    def insert(self, index: int, step: PreProcessingStep) -> None:
+        """Insert a step at a given index"""
+        self.steps.insert(index, step)
+
+    def remove(self, step: PreProcessingStep) -> None:
+        """Remove a step from the pipeline"""
+        self.steps.remove(step)
+
+    def pop(self, index: int) -> PreProcessingStep:
+        """Pop a step at a given index"""
+        return self.steps.pop(index)
+
+    def __call__(self, df: ddf.DataFrame, metadata=None) -> ddf.DataFrame:
+        """Apply the function to the dataframe by calling it directly
+        
+        This is not the recommended way to apply the pipeline to a dataframe.
+        Use the `map` method instead.
+        
+        Args:
+            df: the dataframe to apply the pipeline to
+            meta: the metadata to use for the dataframe
+        
+        Returns:
+            the dataframe with the function applied
+        """
+        df = df or self.df
+        for step in self.steps:
+            df = step(df,metadata=metadata)
+        return df
+
+    def map(self, df: ddf.DataFrame=None, metadata: pd.DataFrame = None) -> ddf.DataFrame:
+        """Apply the pipeline to the dataframe
+        
+        Args:
+            df: the dataframe to apply the pipeline to
+            metadata: the metadata handler where to log usage of the pipeline
+        
+        Returns:
+            the dataframe with the pipeline applied
+        """
+        df = df if df is not None else self.df
+        for step in self.iterate():
+            df = step.map(df, metadata)
+        return df
+
+    def iterate(self) -> Iterator[PreProcessingStep]:
+        """Return an iterator over the steps of the pipeline"""
+
+        return (s for s in self.steps)
+    
+    def _get_df(self, df=None) -> ddf.DataFrame:
+        """Get the dataframe to apply the function to"""
+        if df is None:
+            df = self.df
+        if df is None:
+            raise ValueError("No dataframe provided")
+        return df
+
+    def __repr__(self) -> str:
+        """Return the string representation of the object"""
+        return f"{self.__class__.__name__}({self.steps})"
+
+    def __str__(self) -> str:
+        """Return the string representation of the object"""
+        s = f"{self.__class__.__name__}({self.steps})"
+        return s
+
+    def _repr_html_(self) -> str:
+        """Return the html representation of the object"""
+        s = f"<h3>{self.__class__.__name__}</h3>"
+        s += "<ul>"
+        for step in self.steps:
+            s += f"<li>{step}</li>"
+        s += "</ul>"
+        return s
+
+    def __add__(self, other) -> PreProcessingPipeline:
+        """Add two PreProcessingPipeline objects"""
+        if isinstance(other, PreProcessingStep):
+            return PreProcessingPipeline([*self.steps, other])
+        elif isinstance(other, PreProcessingPipeline):
+            return PreProcessingPipeline([*self.steps, *other.steps])
+        else:
+            raise TypeError(
+                f"Cannot add {self.__class__.__name__} and {other.__class__.__name__}"
+            )
+
+    def __radd__(self, other) -> PreProcessingPipeline:
+        """Add two PreProcessingPipeline objects"""
+        if isinstance(other, PreProcessingStep):
+            return PreProcessingPipeline([other, *self.steps])
+        elif isinstance(other, PreProcessingPipeline):
+            return PreProcessingPipeline([*other.steps, *self.steps])
+        else:
+            raise TypeError(
+                f"Cannot add {self.__class__.__name__} and {other.__class__.__name__}"
+            )
+
+    def __iter__(self) -> Iterator[PreProcessingStep]:
+        """Return an iterator over the steps of the pipeline"""
+        return self.iterate()
+    
+    def __next__(self) -> PreProcessingStep:
+        """Return the next step of the pipeline"""
+        return next(self.iterate())

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -3,6 +3,7 @@
 """
 import pathlib
 from typing import Any
+from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import List
@@ -25,6 +26,9 @@ from sed.core.config import parse_config
 from sed.core.config import save_config
 from sed.core.dfops import apply_jitter
 from sed.core.metadata import MetaHandler
+from sed.core.preprocessing import PreProcessingPipeline 
+from sed.core.preprocessing import PreProcessingStep
+from sed.core.preprocessing import as_pre_processing
 from sed.diagnostics import grid_histogram
 from sed.io import to_h5
 from sed.io import to_nexus
@@ -63,6 +67,7 @@ class SedProcessor:
         folder: str = None,
         runs: Sequence[str] = None,
         collect_metadata: bool = False,
+        pre_processing: Union[PreProcessingPipeline, Sequence[PreProcessingStep]] = None,
         **kwds,
     ):
         """Processor class of sed. Contains wrapper functions defining a work flow
@@ -97,6 +102,11 @@ class SedProcessor:
 
         self._dataframe: Union[pd.DataFrame, ddf.DataFrame] = None
         self._files: List[str] = []
+
+        self._preprocessing_pipeline: Union[
+            PreProcessingPipeline, 
+            Sequence[PreProcessingStep]
+        ] = pre_processing or []
 
         self._binned: xr.DataArray = None
         self._pre_binned: xr.DataArray = None
@@ -1542,3 +1552,34 @@ class SedProcessor:
             raise NotImplementedError(
                 f"Unrecognized file format: {extension}.",
             )
+
+    def pre_process(self) -> ddf.DataFrame:
+        """Apply preprocessing pipeline to dataframe"""
+        if len(self._preprocessing_pipeline) == 0:
+            Warning('No preprocessing steps found, returning original dataframe')
+            return self._dataframe
+        
+        for step in self._preprocessing_pipeline:
+            self._dataframe = step.map(self._dataframe, metadata=self._attributes)
+        return self._dataframe
+    
+    def add_pre_processing(self, step: Union[Callable, PreProcessingStep], *args, **kwargs):
+        """Add a preprocessing step to the pipeline
+        
+        Args:
+            step (Union[Callable, PreProcessingStep]): Preprocessing step to add.
+            *args: Positional arguments passed to the preprocessing step.
+            **kwargs: Keyword arguments passed to the preprocessing step.
+            
+        Raises:
+            TypeError: Raised if the step is not a callable or a PreProcessingStep.
+        """
+        if isinstance(step, Callable):
+            step = PreProcessingStep(step, *args, **kwargs)
+        elif not isinstance(step, PreProcessingStep):
+            raise TypeError("Preprocessing step must be a callable or a PreProcessingStep")
+        self._preprocessing_pipeline.append(step)
+
+    def reset_pre_processing(self):
+        """Reset the preprocessing pipeline"""
+        self._preprocessing_pipeline = []

--- a/sed/core/workflow.py
+++ b/sed/core/workflow.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, Union, List, Dict, Any, Tuple
+
+import dask.dataframe as ddf
+import numpy as np
+import pandas as pd
+import xarray as xr
+from dask.diagnostics import ProgressBar
+
+from .preprocessing import PreProcessingPipeline, PreProcessingStep
+from .metadata import MetaHandler
+from ..binning import bin_dataframe
+from .config import parse_config 
+
+
+class WorkflowManager:
+    """ Single event dataframe workflow manager, from loading to binning"""
+
+    def __init__(
+            self,
+            dataframe:ddf.DataFrame=None,
+            pre_processing: Union[PreProcessingPipeline,list[PreProcessingStep]]=None,
+            metadata: MetaHandler | dict | None = None,
+            config: dict | None = None,
+        ) -> None:
+        if not isinstance(metadata, MetaHandler):
+            metadata = MetaHandler(metadata)
+        self._metadata: MetaHandler = metadata
+        if pre_processing is None:
+            pre_processing = []
+        self._pre_pipe: PreProcessingPipeline = PreProcessingPipeline(
+            pre_processing
+        )
+        # config management is inconsistent with he rest of the code. We should 
+        # move it to sed.core.config and use a ConfigManager class
+        self._config: dict = parse_config(config)
+        if isinstance(dataframe,(ddf.DataFrame,pd.DataFrame)):
+            self._dataframe: pd.DataFrame | ddf.DataFrame = dataframe
+
+
+        self._dimensions: List[str] = []
+        self._coordinates: Dict[Any, Any] = {}
+
+        self._binned_array: xr.DataArray | None = None
+
+    @property
+    def binned_array(self) -> xr.DataArray | None:
+        
+        if self._binned_array is not None:
+            if (self._binned_array.dims == self._dimensions) or \
+                (self._binned_array.coords == self._coordinates):
+                Warning(
+                    "Binned array dimensions and coordinates do not match dataframe. "
+                    "Recompute binning."
+                )
+            return self._binned_array
+        else:
+            raise ValueError("Binned array not yet computed. Run bin_dataframe() first")
+
+    @property
+    def metadata(self) -> MetaHandler:
+        return self._metadata
+    
+    @property
+    def config(self) -> dict:
+        return self._config
+    
+    @property
+    def dataframe(self) -> pd.DataFrame | ddf.DataFrame:
+        return self._dataframe
+    
+    @property
+    def dims(self) -> List[str]:
+        return self._dimensions
+    
+    @dims.setter
+    def dims(self, dims: List[str]) -> None:
+        self._dimensions = dims
+    
+    @property
+    def coords(self) -> Dict[Any, Any]:
+        if len(self._dimensions) != len(self._coordinates):
+            raise ValueError("Number of dimensions and coordinates do not match")
+        return self._coordinates
+    
+    @coords.setter
+    def coords(self, coords: Dict[Any, Any]) -> None:
+        if any([dim not in self._dimensions for dim in coords.keys()]):
+            raise ValueError("Not all coordinates are defined as dimensions")
+        self._coordinates = coords
+    
+    @property
+    def attrs(self) -> Dict[Any, Any]:
+        return self._metadata
+    
+    @attrs.setter
+    def attrs(self, attrs: Dict[Any, Any]) -> None:
+        self._metadata = attrs
+    
+    @property
+    def _bins(self) -> dict:
+        return self._config["bins"]
+    
+    @property
+    def _axes(self) -> list:
+        return self.dims
+    
+    @property
+    def _ranges(self) -> List(Tuple[float, float]):
+        return [(min(x), max(x)) for x in self._coordinates.values()]
+
+    def __repr__(self):
+        return f"WorkflowManager(dataframe={self._dataframe}, pre_processing={self._pre_processing_pipeline}, metadata={self._metadata}, config={self._config})"
+    
+    def __str__(self):
+        s = "Workflow Manager:\n"
+        s += f"data:\n{self._dataframe.__repr__()}\n"
+        s += "Workflow:\n"
+        for i, step in enumerate(self._preprocessing_pipeline):
+            s += f"{i+1}. {str(step)}\n"
+        return s
+
+    def __getitem__(self, key):
+        return self._dataframe[key]
+    
+    def _repr_html_(self):
+        """ html representation of the __str__  method"""
+        return self.__str__().replace("\n", "<br>")
+    
+    def add_dimension(self,dim,coord=None):
+        """Add a dimension to the dataframe"""
+        if dim not in self._dimensions:
+            self._dimensions.append(dim)
+        if coord is not None:
+            self._coordinates[dim] = coord
+    
+    def add_axis(self,axis,coord=None):
+        """Add an axis to the dataframe"""
+        if axis not in self.axis:
+            self.axis[axis] = coord
+
+    def pre_process(self, dataframe: pd.DataFrame | ddf.DataFrame | None = None) -> pd.DataFrame | ddf.DataFrame:
+        """Apply preprocessing pipeline to dataframe"""
+        dataframe = dataframe or self._dataframe
+        self._pre_pipe.map(dataframe, self._metadata)
+        return dataframe
+    
+    def from_parquet(self, path: str | Path, **kwargs) -> ddf.DataFrame:
+        """Load dataframe from path
+        
+        Args:
+            path: path to dataframe
+            **kwargs: keyword arguments passed to dask.dataframe.read_parquet
+            
+        Returns:
+            dask.dataframe.DataFrame
+        """
+        self._dataframe = ddf.read_parquet(path, **kwargs)
+        return self._dataframe
+    
+    def to_parquet(self, path: str | Path, **kwargs) -> None:
+        """Save dataframe to path
+        
+        Args:
+            path: path to dataframe
+            **kwargs: keyword arguments passed to dask.dataframe.DataFrame.to_parquet
+        """
+        self._dataframe.to_parquet(path, **kwargs)
+    
+    def from_dataframe(self, dataframe: pd.DataFrame | ddf.DataFrame, npartitions=2) -> None:
+        """Load dataframe
+        
+        Args:
+            dataframe: dataframe to load
+            npartitions: number of partitions to use for dask dataframe
+        
+        Raises:
+            ValueError: if dataframe is not a pandas or dask dataframe
+        
+        """
+        if isinstance(dataframe, pd.DataFrame):
+            d = ddf.from_pandas(dataframe, npartitions=npartitions)
+        elif isinstance(dataframe, ddf.DataFrame):
+            d = dataframe
+        else:
+            raise ValueError("dataframe must be a pandas or dask dataframe")
+        self._dataframe = dataframe
+
+    def bin(
+            self, 
+            bins: (
+                int | dict | tuple | list[int] | list[np.ndarray] | list[tuple]
+            ) = 100,
+            axes: str | Sequence[str] = None,
+            ranges: Sequence[tuple[float, float]] = None,**kwargs
+        ) -> xr.DataArray:
+        """Bin dataframe
+        
+        Args:
+            bins: number of bins or bin edges. If a list of arrays is given,
+                each array is used as bin edges for the corresponding axis.
+                If a list of tuples is given, each tuple is used as (bins, range)
+                for the corresponding axis. If a dict is given, it must be of the
+                form {axis: bins} or {axis: (bins, range)}
+            axes: The names of the axes (columns) on which to calculate the histogram.
+                The order will be the order of the dimensions in the resulting array.
+                If None, the axes are inferred from bins.
+            ranges: list of tuples containing the start and end point of the binning
+                    range. If None, the ranges are inferred from bins.
+            **kwargs: additional arguments passed to the binning function 
+                (see  :func:`bin_dataframe`)
+                
+        Returns:
+            binned dataframe
+        """
+        bins = bins or self._bins
+        axes = axes or self._axes
+        ranges = ranges or self._ranges
+        # TODO: check config file for binning parameters
+        self._binned_array = bin_dataframe(
+            self._dataframe, 
+            bins=bins,
+            axes=axes,
+            ranges=ranges,
+            **kwargs)
+        return bin_dataframe(self._dataframe, **kwargs)
+    
+    def to_json(self, fname: str | Path = None, key: str = "") -> dict:
+        """Save the current workflow to a json file
+
+        Args:
+            fname: file where to write the workflow. If none, no file is saved.
+                Defaults to None
+            key: key in the file where to write. Defaults to ''
+
+        Raises:
+            NotImplementedError: # TODO: make this
+
+        Returns:
+            dictionary with the workflow steps
+        """
+        raise NotImplementedError
+
+    def to_parquet(
+        self,
+        fname: str | Path,
+        run_workflow: bool = True,
+    ) -> None:
+        """Save the dataframe as parquet
+
+        Args:
+            fname: path where to save the dataframe
+            run_workflow: if true, it computes the workflow before saving, else
+                it saves the current version of the dataframe.
+
+        Raises:
+            NotImplementedError: # TODO: make this
+        """
+        raise NotImplementedError
+
+    def to_nexus(self) -> Path:
+        """creates a nexus file from the binned data
+
+        Returns:
+            path to the file generated
+        """
+        raise NotImplementedError

--- a/sed/loader/flash/loader.py
+++ b/sed/loader/flash/loader.py
@@ -737,8 +737,13 @@ class FlashLoader(BaseLoader):
             # Channels to fill NaN values
             channels: List[str] = self.get_channels_by_format(["per_pulse", "per_train"])
 
-            # Fill NaN values
-            dataframe[channels] = dataframe[channels].ffill()
+            # Define a custom function to forward fill specified columns
+            def forward_fill_partition(df):
+                df[channels] = df[channels].ffill()
+                return df
+
+            # Use map_overlap to apply forward_fill_partition
+            dataframe = dataframe.map_overlap(forward_fill_partition, before=0, after=1)
 
             # Remove the NaNs from per_electron channels
             dataframe = dataframe.dropna(

--- a/sed/loader/flash/loader.py
+++ b/sed/loader/flash/loader.py
@@ -29,6 +29,9 @@ from sed.loader.base.loader import BaseLoader
 from sed.loader.flash.metadata import MetadataRetriever
 from sed.loader.utils import parse_h5_keys
 
+from tqdm.auto import trange, tqdm
+import time
+
 
 class FlashLoader(BaseLoader):
     """
@@ -675,6 +678,7 @@ class FlashLoader(BaseLoader):
         print("All files converted successfully!")
 
         return h5_filenames, parquet_filenames
+
 
     def parquet_handler(
         self,

--- a/sed/loader/flash/loader.py
+++ b/sed/loader/flash/loader.py
@@ -15,6 +15,7 @@ from typing import Tuple
 from typing import Union
 
 import dask.dataframe as dd
+from dask.diagnostics import ProgressBar
 import h5py
 import numpy as np
 from joblib import delayed
@@ -742,8 +743,14 @@ class FlashLoader(BaseLoader):
                 df[channels] = df[channels].ffill()
                 return df
 
+            # calculate the number of rows in each partition
+            with ProgressBar():
+                print("Computing dataframe shape...")
+                nrows = dataframe.map_partitions(len).compute()
+                max_part_size = min(nrows)
+
             # Use map_overlap to apply forward_fill_partition
-            dataframe = dataframe.map_overlap(forward_fill_partition, before=0, after=1)
+            dataframe = dataframe.map_overlap(forward_fill_partition, before=max_part_size+1, after=0)
 
             # Remove the NaNs from per_electron channels
             dataframe = dataframe.dropna(

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,94 @@
+"""This file contains code that performs several tests for the preprocessing functions
+using pytest
+"""
+import pytest
+
+import numpy as np
+import pandas as pd
+
+
+from sed.core.preprocessing import PreProcessingPipeline
+from sed.core.preprocessing import PreProcessingStep
+from sed.core.preprocessing import as_pre_processing
+
+N_PTS = 100
+cols = ["posx", "posy", "energy"]
+df = pd.DataFrame(np.random.randn(N_PTS, len(cols)), columns=cols)
+
+def square(df,col):
+    df[f'{col}_squared'] = df[col] ** 2
+    return df
+
+def add(df,col,value):
+    df[f'{col}_added'] = df[col] + value
+    return df
+
+def test_pp_decorator():
+    """ test the PreProcessingStep decorator """
+    def square(df,col):
+        df[f'col_squared'] = df[col] ** 2
+        return df
+    square_dec = as_pre_processing(square(col='posx'))
+    pp = square_dec(col='posx')
+    assert isinstance(pp, PreProcessingStep)
+    assert pp.func == square
+    assert pp.kwargs == {'col': 'posx'}
+    assert pp.args == ()
+    assert pp.col == 'posx'
+
+def test_pp_decorator_with_parameters():
+    """ test the PreProcessingStep decorator """
+    def add(df,col,value):
+        df[f'col_added'] = df[col] + value
+        return df
+    add_dec = as_pre_processing(add(col='posx',value=1))
+    pp = add_dec(col='posx',value=1)
+    assert isinstance(pp, PreProcessingStep)
+    assert pp.func == add
+    assert pp.kwargs == {'col': 'posx', 'value': 1}
+    assert pp.args == ()
+    assert pp.col == 'posx'
+
+
+def test_pp_decorator_error_missing_parameters():
+    """ test that the decorator rises an error when missing parameters """
+    def add(df,col,value):
+        df[f'col_added'] = df[col] + value
+        return df
+    add_dec = as_pre_processing(add(col='posx'))
+    pp = add_dec(col='posx',value=1)
+    assert isinstance(pp, PreProcessingStep)
+    with pytest.raises(TypeError):
+        pp(df)
+
+
+def test_pp_decorator_error_wrong_parameters():
+    """ test that the decorator rises an error when wrong parameters """
+    def add(df,col,value):
+        df[f'col_added'] = df[col] + value
+        return df
+    add_dec = as_pre_processing(add(col='posx',value='asd'))
+    pp = add_dec(col='posx',value=1)
+    assert isinstance(pp, PreProcessingStep)
+    with pytest.raises(TypeError):
+        pp(df)
+
+
+def test_preprocessing_pipeline():
+    """Test the PreProcessingStep class"""
+    def square(df):
+        return df ** 2
+
+    def add(df, value):
+        return df + value
+
+    square_step = PreProcessingStep(square)
+    add_step = PreProcessingStep(add, args=(1,))
+    pipeline = square_step + add_step
+    assert isinstance(pipeline, PreProcessingPipeline)
+    assert len(pipeline.steps) == 2
+    assert isinstance(pipeline.steps[0], PreProcessingStep)
+    assert isinstance(pipeline.steps[1], PreProcessingStep)
+    assert pipeline.steps[0].func == square
+    assert pipeline.steps[1].func == add
+    assert pipeline.steps[1].args == (1,)


### PR DESCRIPTION
After a few attempts with different options, I found that apparently (perhaps recently) multiple files can be loaded directly using read_parquet from dask so if I do that and just perform an ffill on the necessary channels, it works. dask seems to be handling the chunking etc. at least from the tests I did