### PR TITLE
Dependabot config update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-type: "direct"
+      - dependency-type: "all"
     versioning-strategy: "lockfile-only"
     groups:
       dependencies:


### PR DESCRIPTION
The last config update does the right thing in only updating the lockfile, and grouping dependency updates, but misses all indirect dependencies.
From the generated lockfile, poetry update generates the following remaining updates:

```
Package operations: 0 installs, 12 updates, 0 removals

  • Updating jupyter-core (5.3.2 -> 5.4.0)
  • Updating jupyter-client (8.3.1 -> 8.4.0)
  • Updating charset-normalizer (3.3.0 -> 3.3.1)
  • Updating cycler (0.12.0 -> 0.12.1)
  • Updating fonttools (4.43.0 -> 4.43.1)
  • Updating pillow (10.0.1 -> 10.1.0)
  • Updating cloudpickle (2.2.1 -> 3.0.0)
  • Updating fsspec (2023.9.2 -> 2023.10.0)
  • Updating numcodecs (0.11.0 -> 0.12.1)
  • Updating traits (6.4.2 -> 6.4.3)
  • Updating gitdb (4.0.10 -> 4.0.11)
  • Updating gitpython (3.1.37 -> 3.1.40)
```

This PR is for trying the "dependency-type: "all" option to see if that generates the correct behavior.