### PR TITLE
ignore dependabot branches from triggering workflow

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -5,6 +5,8 @@ on:
     - cron:  '0 1 * * 1'
   workflow_dispatch:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - pyproject.toml
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -5,8 +5,7 @@ on:
     - cron:  '0 1 * * 1'
   workflow_dispatch:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches: main
     paths:
       - pyproject.toml
 


### PR DESCRIPTION
This should fix the problem in #256 by disabling the workflow for dependabot actions.