### PR TITLE
Add filter for index and on-the-fly filter

### DIFF
--- a/sed/core/dfops.py
+++ b/sed/core/dfops.py
@@ -98,7 +98,8 @@ def apply_filter(
 
     Args:
         df (Union[pd.DataFrame, dask.dataframe.DataFrame]): Dataframe to use.
-        col (str): Name of the column to filter.
+        col (str): Name of the column to filter. Passing "index" for col will
+            filter on the index in each dataframe partition.
         lower_bound (float, optional): The lower bound used in the filtering.
             Defaults to -np.inf.
         upper_bound (float, optional): The lower bound used in the filtering.
@@ -107,7 +108,14 @@ def apply_filter(
     Returns:
         Union[pd.DataFrame, dask.dataframe.DataFrame]: The filtered dataframe.
     """
+    df = df.copy()
+    if col == "index":
+        df["index"] = df.index
+
     out_df = df[(df[col] > lower_bound) & (df[col] < upper_bound)]
+
+    if col == "index":
+        out_df = drop_column(out_df, "index")
 
     return out_df
 
@@ -157,8 +165,8 @@ def add_time_stamped_data(
 def map_columns_2d(
     df: Union[pd.DataFrame, dask.dataframe.DataFrame],
     map_2d: Callable,
-    x_column: np.ndarray,
-    y_column: np.ndarray,
+    x_column: str,
+    y_column: str,
     **kwds,
 ) -> Union[pd.DataFrame, dask.dataframe.DataFrame]:
     """Apply a 2-dimensional mapping simultaneously to two dimensions.
@@ -166,8 +174,8 @@ def map_columns_2d(
     Args:
         df (Union[pd.DataFrame, dask.dataframe.DataFrame]): Dataframe to use.
         map_2d (Callable): 2D mapping function.
-        x_column (np.ndarray): The X column of the dataframe to apply mapping to.
-        y_column (np.ndarray): The Y column of the dataframe to apply mapping to.
+        x_column (str): The X column of the dataframe to apply mapping to.
+        y_column (str): The Y column of the dataframe to apply mapping to.
         **kwds: Additional arguments for the 2D mapping function.
 
     Returns:

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -422,7 +422,7 @@ class SedProcessor:
             min_value (float, optional): Minimum value to keep. Defaults to None.
             max_value (float, optional): Maximum value to keep. Defaults to None.
         """
-        if column not in self._dataframe.columns:
+        if column != "index" and column not in self._dataframe.columns:
             raise KeyError(f"Column {column} not found in dataframe!")
         if min_value >= max_value:
             raise ValueError("min_value has to be smaller than max_value!")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -796,6 +796,63 @@ def test_compute():
     assert result.data.sum(axis=(0, 1, 2, 3)) > 0
 
 
+def test_compute_with_filter():
+    """Test binning of final result using filters"""
+    config = parse_config(
+        config={"core": {"loader": "mpes"}},
+        folder_config={},
+        user_config={},
+        system_config={},
+    )
+    processor = SedProcessor(
+        folder=df_folder,
+        config=config,
+        folder_config={},
+        user_config={},
+        system_config={},
+    )
+    bins = [10, 10, 10, 10]
+    axes = ["X", "Y", "t", "ADC"]
+    ranges = [[0, 2048], [0, 2048], [0, 200000], [0, 50000]]
+    filters = [
+        {"col": "X", "lower_bound": 100, "upper_bound": 200},
+        {"col": "index", "lower_bound": 100, "upper_bound": 200},
+    ]
+    result = processor.compute(bins=bins, axes=axes, ranges=ranges, df_partitions=5)
+    result_filtered = processor.compute(
+        bins=bins,
+        axes=axes,
+        ranges=ranges,
+        df_partitions=5,
+        filter=filters,
+    )
+    assert result.sum(axis=(0, 1, 2, 3)) > result_filtered.sum(axis=(0, 1, 2, 3))
+    with pytest.raises(ValueError) as e:
+        processor.compute(
+            bins=bins,
+            axes=axes,
+            ranges=ranges,
+            df_partitions=5,
+            filter=[{"lower_bound": 100}],
+        )
+    assert str(e.value.args[0]).find("'col' needs to be defined for each filter entry!") > -1
+
+    with pytest.raises(ValueError) as e:
+        processor.compute(
+            bins=bins,
+            axes=axes,
+            ranges=ranges,
+            df_partitions=5,
+            filter=[{"col": "X", "invalid": 100}],
+        )
+    assert (
+        str(e.value.args[0]).find(
+            "Only 'col', 'lower_bound' and 'upper_bound' allowed as filter entries. ",
+        )
+        > -1
+    )
+
+
 def test_compute_with_normalization():
     """Test binning of final result with histogram normalization"""
     config = parse_config(


### PR DESCRIPTION
This PR adds the option to filter on the event index per partition, and adds a keyword parameter to the compute function to filter the dataframe on-the-fly during binning