### PR TITLE
Exception handling for binning when df cols are of non-numeric types

### DIFF
--- a/sed/binning/binning.py
+++ b/sed/binning/binning.py
@@ -173,8 +173,8 @@ def bin_partition(
         vals = part.iloc[:, col_id].values
     if vals.dtype == "object":
         raise ValueError(
-            "Numba binning requires all binned dataframe columns to be of the same type. "
-            "Encountered data types where "
+            "Binning requires all binned dataframe columns to be of numeric type. "
+            "Encountered data types were "
             f"{[part.columns[id] + ': ' + str(part.iloc[:, id].dtype) for id in col_id]}. "
             "Please make sure all axes data are of numeric type.",
         )

--- a/sed/binning/binning.py
+++ b/sed/binning/binning.py
@@ -171,12 +171,14 @@ def bin_partition(
         vals = sel_part.values
     else:
         vals = part.iloc[:, col_id].values
+    if vals.dtype == "object":
+        raise ValueError(
+            "Numba binning requires all binned dataframe columns to be of the same type. "
+            "Encountered data types where "
+            f"{[part.columns[id] + ': ' + str(part.iloc[:, id].dtype) for id in col_id]}. "
+            "Please make sure all axes data are of numeric type.",
+        )
     if hist_mode == "numba":
-        if vals.dtype == "object":
-            raise ValueError(
-                "Numba binning requires all axes data to be of the same type. "
-                "Please make sure all axes data are of the same type, or use numpy binning. ",
-            )
         hist_partition, edges = numba_histogramdd(
             vals,
             bins=bins,

--- a/sed/binning/binning.py
+++ b/sed/binning/binning.py
@@ -170,8 +170,13 @@ def bin_partition(
                 apply_jitter_on_column(sel_part, amp * binsize, col, mode)
         vals = sel_part.values
     else:
-        vals = part.values[:, col_id]
+        vals = part.iloc[:, col_id].values
     if hist_mode == "numba":
+        if vals.dtype == "object":
+            raise ValueError(
+                "Numba binning requires all axes data to be of the same type. "
+                "Please make sure all axes data are of the same type, or use numpy binning. ",
+            )
         hist_partition, edges = numba_histogramdd(
             vals,
             bins=bins,

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -484,6 +484,20 @@ def test_bin_partition() -> None:
     assert np.allclose(cast(np.ndarray, res), res1)
 
 
+def test_non_numeric_dtype_error() -> None:
+    """Test bin_partition function"""
+    pdf = sample_pdf.astype({"x": "string", "y": "int32", "z": "int32"})
+    with pytest.raises(ValueError) as err:
+        _ = bin_partition(
+            part=pdf,
+            bins=bins,  # type: ignore[arg-type]
+            axes=columns,
+            ranges=ranges,
+            skip_test=False,
+        )
+    assert "Encountered data types were ['x: string', 'y: int32', 'z: int32']" in str(err.value)
+
+
 def test_bin_dataframe() -> None:
     """Test bin_dataframe function"""
     res = bin_dataframe(df=sample_ddf, bins=bins, axes=columns, ranges=ranges)


### PR DESCRIPTION
Several people have reported a bug per email with 
```
TypingError: Failed in nopython pipeline (step: nopython frontend)
non-precise type array (pyobject, 2d, F)
```
A quick fix was to just use hist_mode: numpy.

Now I finally managed to track it down to the cause. When the dtypes of different cols that are being binned are not the same, such as int16 and float32, numpy treats the array as a type object. 
Usually, numpy infers these types and choose the highest precision type for all in array automatically. However, if you do df.values, it is an object. But somehow choosing columns and then getting values makes numpy choose the array type correctly.

I also added an exception in case the array type is still an object.

![image](https://github.com/OpenCOMPES/sed/assets/10053031/9ddfdf69-858a-4c83-9bbc-9ea34f3fd0a9)

