### PR TITLE
Html representation of processor and metadata in notebooks

### DIFF
--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -44,6 +44,14 @@ class MetaHandler:
         html = self._format_attributes(self._m)
         return html
 
+    @property
+    def metadata(self) -> Dict:
+        """Property returning the metadata dict.
+        Returns:
+            dict: Dictionary of metadata.
+        """
+        return self._m
+
     def add(
         self,
         entry: Any,

--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -1,5 +1,4 @@
 """This is a metadata handler class from the sed package
-
 """
 import json
 from copy import deepcopy
@@ -10,7 +9,8 @@ from sed.core.config import complete_dictionary
 
 
 class MetaHandler:
-    """[summary]"""
+    """This class provides methods to manipulate metadata dictionaries,
+    and give a nice representation of them."""
 
     def __init__(self, meta: Dict = None) -> None:
         self._m = deepcopy(meta) if meta is not None else {}
@@ -22,13 +22,14 @@ class MetaHandler:
         return json.dumps(self._m, default=str, indent=4)
 
     def _format_attributes(self, attributes, indent=0):
+        INDENT_FACTOR = 20
         html = ""
         for key, value in attributes.items():
             # Format key
             formatted_key = key.replace("_", " ").title()
             formatted_key = f"<b>{formatted_key}</b>"
 
-            html += f"<div style='padding-left: {indent * 10}px;'>"
+            html += f"<div style='padding-left: {indent * INDENT_FACTOR}px;'>"
             if isinstance(value, dict):
                 html += f"<details><summary>{formatted_key} [{key}]</summary>"
                 html += self._format_attributes(value, indent + 1)
@@ -107,83 +108,17 @@ class MetaHandler:
                 f"Please choose between overwrite,append or raise.",
             )
 
-    def add_processing(self, method: str, **kwds: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        # TODO: #36 Add processing metadata validation tests
-        self._m["processing"][method] = kwds
-
-    def from_nexus(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
-    def to_nexus(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
-    def from_json(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
-    def to_json(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
-    def from_dict(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
-    def to_dict(self, val: Any) -> None:
-        """docstring
-
-        Args:
-
-        Returns:
-
-        """
-        raise NotImplementedError()
-
 
 class DuplicateEntryError(Exception):
-    """[summary]"""
+    """Exception raised when attempting to add a duplicate entry to the metadata container.
 
+    Attributes:
+        message -- explanation of the error
+    """
 
-if __name__ == "__main__":
-    m = MetaHandler()
-    m.add({"start": 0, "stop": 1}, name="test")
-    print(m)
+    def __init__(self, message: str = "An entry already exists in metadata"):
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.message}"

--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -1,11 +1,10 @@
 """This is a metadata handler class from the sed package
 
 """
+import json
 from copy import deepcopy
 from typing import Any
 from typing import Dict
-
-import yaml
 
 from sed.core.config import complete_dictionary
 
@@ -20,7 +19,7 @@ class MetaHandler:
         return self._m[val]
 
     def __repr__(self) -> str:
-        return yaml.dump(self._m, allow_unicode=True, default_flow_style=False)
+        return json.dumps(self._m, default=str, indent=4)
 
     def _format_attributes(self, attributes, indent=0):
         html = ""
@@ -44,15 +43,6 @@ class MetaHandler:
     def _repr_html_(self) -> str:
         html = self._format_attributes(self._m)
         return html
-
-    @property
-    def metadata(self) -> dict:
-        """Property returning the metadata dict.
-
-        Returns:
-            dict: Dictionary of metadata.
-        """
-        return self._m
 
     def add(
         self,

--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from typing import Any
 from typing import Dict
 
+import yaml
+
 from sed.core.config import complete_dictionary
 
 
@@ -18,8 +20,7 @@ class MetaHandler:
         return self._m[val]
 
     def __repr__(self) -> str:
-        # TODO: #35 add pretty print, possibly to HTML
-        return str(self._m)
+        return yaml.dump(self._m, allow_unicode=True, default_flow_style=False)
 
     @property
     def metadata(self) -> dict:

--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -22,6 +22,30 @@ class MetaHandler:
     def __repr__(self) -> str:
         return yaml.dump(self._m, allow_unicode=True, default_flow_style=False)
 
+    def _format_attributes(self, attributes, indent=0):
+        html = ""
+        for key, value in attributes.items():
+            # Format key
+            formatted_key = key.replace("_", " ").title()
+            formatted_key = f"<b>{formatted_key}</b>"
+
+            if isinstance(value, dict):
+                html += f"<div style='padding-left: {indent * 10}px;'><details>"
+                html += f"<summary>{formatted_key}</summary>"
+                html += self._format_attributes(value, indent + 1)
+                html += "</details></div>"
+            else:
+                html += (
+                    f"<div style='padding-left: {indent * 10}px;'>{formatted_key}: {value}</div>"
+                )
+        return html
+
+    def _repr_html_(self) -> str:
+        html = "<div>"
+        html += self._format_attributes(self._m)
+        html += "</div>"
+        return html
+
     @property
     def metadata(self) -> dict:
         """Property returning the metadata dict.

--- a/sed/core/metadata.py
+++ b/sed/core/metadata.py
@@ -29,21 +29,20 @@ class MetaHandler:
             formatted_key = key.replace("_", " ").title()
             formatted_key = f"<b>{formatted_key}</b>"
 
+            html += f"<div style='padding-left: {indent * 10}px;'>"
             if isinstance(value, dict):
-                html += f"<div style='padding-left: {indent * 10}px;'><details>"
-                html += f"<summary>{formatted_key}</summary>"
+                html += f"<details><summary>{formatted_key} [{key}]</summary>"
                 html += self._format_attributes(value, indent + 1)
-                html += "</details></div>"
+                html += "</details>"
+            elif hasattr(value, "shape"):
+                html += f"{formatted_key} [{key}]: {value.shape}"
             else:
-                html += (
-                    f"<div style='padding-left: {indent * 10}px;'>{formatted_key}: {value}</div>"
-                )
+                html += f"{formatted_key} [{key}]: {value}"
+            html += "</div>"
         return html
 
     def _repr_html_(self) -> str:
-        html = "<div>"
-        html += self._format_attributes(self._m)
-        html += "</div>"
+        html = self._format_attributes(self._m)
         return html
 
     @property

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -178,9 +178,41 @@ class SedProcessor:
             df_str = "Data Frame: No Data loaded"
         else:
             df_str = self._dataframe.__repr__()
-        attributes_str = f"Metadata: {self._attributes.metadata}"
-        pretty_str = df_str + "\n" + attributes_str
+        pretty_str = df_str + "\n" + "Metadata: " + "\n" + self._attributes.__repr__()
         return pretty_str
+
+    def _repr_html_(self):
+        html = "<div>"
+
+        html += (
+            f"<details><summary>Dataframe</summary>{self.dataframe.head()._repr_html_()}</details>"
+        )
+
+        # Add expandable section for dataframe
+        html += f"<details><summary>Dask</summary>{self.dataframe._repr_html_()}</details>"
+
+        # Add expandable section for attributes
+        html += "<details><summary>Attributes</summary>"
+        html += "<ul>"
+        html += f"<li>{self.attributes}</li>"
+        html += "</ul></details>"
+
+        # Add expandable section for plots
+        html += "<details><summary>Plots</summary>"
+        # Add your plot generating code here
+        plt.figure()
+        # plot random data
+        plt.plot(np.random.rand(10))
+        plt.xlabel("X-axis label")
+        plt.ylabel("Y-axis label")
+        plt.title("Plot Title")
+        html += "<img src='plot.png' alt='Plot'>"
+        plt.close()
+        html += "</details>"
+
+        html += "</div>"
+
+        return html
 
     @property
     def dataframe(self) -> Union[pd.DataFrame, ddf.DataFrame]:
@@ -238,13 +270,13 @@ class SedProcessor:
         self._timed_dataframe = timed_dataframe
 
     @property
-    def attributes(self) -> dict:
+    def attributes(self) -> MetaHandler:
         """Accessor to the metadata dict.
 
         Returns:
             dict: The metadata dict.
         """
-        return self._attributes.metadata
+        return self._attributes
 
     def add_attribute(self, attributes: dict, name: str, **kwds):
         """Function to add element to the attributes dict.

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -192,10 +192,9 @@ class SedProcessor:
         html += f"<details><summary>Dask</summary>{self.dataframe._repr_html_()}</details>"
 
         # Add expandable section for attributes
-        html += "<details><summary>Attributes</summary>"
-        html += "<ul>"
-        html += f"<li>{self.attributes}</li>"
-        html += "</ul></details>"
+        html += "<details><summary>Metadata</summary>"
+        html += self.attributes._repr_html_()
+        html += "</details>"
 
         # Add expandable section for plots
         html += "<details><summary>Plots</summary>"

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -274,7 +274,7 @@ class SedProcessor:
         """Accessor to the metadata dict.
 
         Returns:
-            dict: The metadata dict.
+            MetaHandler: The metadata object
         """
         return self._attributes
 

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -175,7 +175,7 @@ class SedProcessor:
 
     def __repr__(self):
         if self._dataframe is None:
-            df_str = "Data Frame: No Data loaded"
+            df_str = "Dataframe: No Data loaded"
         else:
             df_str = self._dataframe.__repr__()
         pretty_str = df_str + "\n" + "Metadata: " + "\n" + self._attributes.__repr__()
@@ -184,28 +184,28 @@ class SedProcessor:
     def _repr_html_(self):
         html = "<div>"
 
-        html += (
-            f"<details><summary>Dataframe</summary>{self.dataframe.head()._repr_html_()}</details>"
-        )
+        if self._dataframe is None:
+            df_html = "Dataframe: No Data loaded"
+        else:
+            df_html = self._dataframe._repr_html_()
 
-        # Add expandable section for dataframe
-        html += f"<details><summary>Dask</summary>{self.dataframe._repr_html_()}</details>"
+        html += f"<details><summary>Dataframe</summary>{df_html}</details>"
 
         # Add expandable section for attributes
         html += "<details><summary>Metadata</summary>"
-        html += self.attributes._repr_html_()
-        html += "</details>"
-
-        # Add expandable section for plots
-        html += "<details><summary>Plots</summary>"
-        # Something like the event histogram can be added here,
-        # but the method needs to output image/html
-        # self.view_event_histogram(dfpid=2, backend="matplotlib")
-        html += "</details>"
+        html += "<div style='padding-left: 10px;'>"
+        html += self._attributes._repr_html_()
+        html += "</div></details>"
 
         html += "</div>"
 
         return html
+
+    ## Suggestion:
+    # @property
+    # def overview_panel(self):
+    #     """Provides an overview panel with plots of different data attributes."""
+    #     self.view_event_histogram(dfpid=2, backend="matplotlib")
 
     @property
     def dataframe(self) -> Union[pd.DataFrame, ddf.DataFrame]:

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -198,15 +198,9 @@ class SedProcessor:
 
         # Add expandable section for plots
         html += "<details><summary>Plots</summary>"
-        # Add your plot generating code here
-        plt.figure()
-        # plot random data
-        plt.plot(np.random.rand(10))
-        plt.xlabel("X-axis label")
-        plt.ylabel("Y-axis label")
-        plt.title("Plot Title")
-        html += "<img src='plot.png' alt='Plot'>"
-        plt.close()
+        # Something like the event histogram can be added here,
+        # but the method needs to output image/html
+        # self.view_event_histogram(dfpid=2, backend="matplotlib")
         html += "</details>"
 
         html += "</div>"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any
+from typing import Dict
+
+import numpy as np
+import pytest
+
+from sed.core.metadata import DuplicateEntryError
+from sed.core.metadata import MetaHandler
+
+metadata: Dict[Any, Any] = {}
+metadata["entry_title"] = "Title"
+# sample
+metadata["sample"] = {}
+metadata["sample"]["size"] = np.array([1, 2, 3])
+metadata["sample"]["name"] = "Sample Name"
+
+
+@pytest.fixture
+def meta_handler():
+    # Create a MetaHandler instance
+    return MetaHandler(meta=metadata)
+
+
+def test_add_entry_overwrite(meta_handler):
+    # Add a new entry to metadata with 'overwrite' policy
+    new_entry = {"sample": "Sample Name"}
+    meta_handler.add(new_entry, "sample", duplicate_policy="overwrite")
+    assert "sample" in meta_handler.metadata
+    assert meta_handler.metadata["sample"] == new_entry
+
+
+def test_add_entry_raise(meta_handler):
+    # Attempt to add a duplicate entry with 'raise' policy
+    with pytest.raises(DuplicateEntryError):
+        meta_handler.add({}, "entry_title", duplicate_policy="raise")
+
+
+def test_add_entry_append(meta_handler):
+    # Add a new entry to metadata with 'append' policy
+    new_entry = {"sample": "Sample Name"}
+    meta_handler.add(new_entry, "sample", duplicate_policy="append")
+    assert "sample" in meta_handler.metadata
+    assert "sample_1" in meta_handler.metadata
+    assert meta_handler.metadata["sample_1"] == new_entry
+
+
+def test_add_entry_merge(meta_handler):
+    # Add a new entry to metadata with 'merge' policy
+    entry_to_merge = {"name": "Name", "type": "type"}
+    meta_handler.add(entry_to_merge, "sample", duplicate_policy="merge")
+    print(meta_handler.metadata)
+    assert "sample" in meta_handler.metadata
+    assert "name" in meta_handler.metadata["sample"]
+    assert "type" in meta_handler.metadata["sample"]
+
+
+def test_repr(meta_handler):
+    # Test the __repr__ method
+    assert repr(meta_handler) == json.dumps(metadata, default=str, indent=4)
+
+
+def test_repr_html(meta_handler):
+    # Test the _repr_html_ method
+    html = meta_handler._format_attributes(metadata)
+    assert meta_handler._repr_html_() == html
+
+    html_test = "<div style='padding-left: 0px;'><b>Entry Title</b> [entry_title]: Title</div>"
+    html_test += (
+        "<div style='padding-left: 0px;'><details><summary><b>Sample</b> [sample]</summary>"
+    )
+    html_test += "<div style='padding-left: 20px;'><b>Size</b> [size]: (3,)</div>"
+    html_test += "<div style='padding-left: 20px;'><b>Name</b> [name]: Sample Name"
+    html_test += "</div></details></div>"
+    assert html == html_test

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -189,11 +189,11 @@ def test_attributes_setters() -> None:
         processor.dataframe["X"].compute(),
         processor.dataframe["Y"].compute(),
     )
-    processor_metadata = processor.attributes
+    processor_metadata = processor.attributes.metadata
     assert isinstance(processor_metadata, dict)
     assert "test" in processor_metadata.keys()
     processor.add_attribute({"key2": 5}, name="test2")
-    assert processor.attributes["test2"]["key2"] == 5
+    assert processor_metadata["test2"]["key2"] == 5
     assert processor.config["core"]["loader"] == "mpes"
     assert len(processor.files) == 2
 
@@ -398,7 +398,7 @@ def test_pose_adjustment_save_load() -> None:
     processor.apply_momentum_correction()
     assert "Xm" in processor.dataframe.columns
     assert "Ym" in processor.dataframe.columns
-    assert "momentum_correction" in processor.attributes
+    assert "momentum_correction" in processor.attributes.metadata
     os.remove("sed_config_pose_adjustments.yaml")
 
 
@@ -609,7 +609,10 @@ def test_energy_calibration_workflow(energy_scale: str, calibration_method: str)
         processor.add_energy_offset(constant=1)
     processor.append_energy_axis(preview=False)
     assert "energy" in processor.dataframe.columns
-    assert processor.attributes["energy_calibration"]["calibration"]["energy_scale"] == energy_scale
+    assert (
+        processor.attributes.metadata["energy_calibration"]["calibration"]["energy_scale"]
+        == energy_scale
+    )
     os.remove(f"sed_config_energy_calibration_{energy_scale}-{calibration_method}.yaml")
 
     energy1 = processor.dataframe["energy"].compute().values
@@ -743,11 +746,14 @@ def test_delay_calibration_workflow() -> None:
     processor.calibrate_delay_axis()
     assert "delay" in processor.dataframe.columns
     assert (
-        processor.attributes["delay_calibration"]["calibration"]["creation_date"]
+        processor.attributes.metadata["delay_calibration"]["calibration"]["creation_date"]
         == creation_date_calibration
     )
     processor.add_delay_offset(preview=True)
-    assert processor.attributes["delay_offset"]["offsets"]["creation_date"] == creation_date_offsets
+    assert (
+        processor.attributes.metadata["delay_offset"]["offsets"]["creation_date"]
+        == creation_date_offsets
+    )
     np.testing.assert_allclose(expected, processor.dataframe["delay"].compute())
     os.remove("sed_config_delay_calibration.yaml")
 
@@ -819,9 +825,12 @@ def test_add_time_stamped_data() -> None:
     res = processor.dataframe["time_stamped_data"].compute().values
     assert res[0] == 0
     assert res[-1] == 1
-    assert processor.attributes["time_stamped_data"][0] == "time_stamped_data"
-    np.testing.assert_array_equal(processor.attributes["time_stamped_data"][1], time_stamps)
-    np.testing.assert_array_equal(processor.attributes["time_stamped_data"][2], data)
+    assert processor.attributes.metadata["time_stamped_data"][0] == "time_stamped_data"
+    np.testing.assert_array_equal(
+        processor.attributes.metadata["time_stamped_data"][1],
+        time_stamps,
+    )
+    np.testing.assert_array_equal(processor.attributes.metadata["time_stamped_data"][2], data)
 
 
 def test_event_histogram() -> None:


### PR DESCRIPTION
This PR introduces an expandable representation of the data and metadata, and perhaps plots. We can discuss what should be included and what not.
Just type `sp` in a notebook after processor class has been instantiated and it will output the html version.

But also the metadata repr is interesting:
To test: you can write `sp.attributes` in a notebook and that will give the html representation.
If `print(sp.attributes)` is used, it gives a yaml representation, which is also more human readable than json.

closes #35 

