### PR TITLE
using importlib to get package version

### DIFF
--- a/.github/workflows/testing_coverage.yml
+++ b/.github/workflows/testing_coverage.yml
@@ -29,6 +29,7 @@ jobs:
       # Run pytest with coverage report, saving to xml
       - name: Run tests on python 3.8
         run: |
+          poetry install
           poetry run pytest --cov --cov-report xml:cobertura.xml --full-trace --show-capture=no -sv -n auto tests/
 
       # Take report and upload to coveralls

--- a/.github/workflows/testing_coverage.yml
+++ b/.github/workflows/testing_coverage.yml
@@ -26,10 +26,12 @@ jobs:
           python-version: 3.8
           poetry-version: 1.2.2
 
+      - name: Install project dependencies
+        run: poetry install
+
       # Run pytest with coverage report, saving to xml
       - name: Run tests on python 3.8
         run: |
-          poetry install
           poetry run pytest --cov --cov-report xml:cobertura.xml --full-trace --show-capture=no -sv -n auto tests/
 
       # Take report and upload to coveralls

--- a/.github/workflows/testing_multiversion.yml
+++ b/.github/workflows/testing_multiversion.yml
@@ -30,4 +30,5 @@ jobs:
       # Use cached python and dependencies, install poetry
       - name: Run tests on python ${{matrix.python-version}}
         run: |
+          poetry install
           poetry run pytest --full-trace --show-capture=no -sv -n auto tests/

--- a/.github/workflows/testing_multiversion.yml
+++ b/.github/workflows/testing_multiversion.yml
@@ -27,8 +27,10 @@ jobs:
           python-version: ${{matrix.python-version}}
           poetry-version: 1.2.2
 
+      - name: Install project dependencies
+        run: poetry install
+
       # Use cached python and dependencies, install poetry
       - name: Run tests on python ${{matrix.python-version}}
         run: |
-          poetry install
           poetry run pytest --full-trace --show-capture=no -sv -n auto tests/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 OpenCOMPES
+Copyright (c) 2022-2024 OpenCOMPES
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ def _get_project_meta():
 
 pkg_meta = _get_project_meta()
 project = str(pkg_meta["name"])
-copyright = "2022, OpenCOMPES team"
+copyright = "2024, OpenCOMPES team"
 author = "OpenCOMPES team"
 
 # The short X.Y version

--- a/sed/__init__.py
+++ b/sed/__init__.py
@@ -1,7 +1,7 @@
-"""sed module easy access APIs
+"""sed module easy access APIs."""
+import importlib.metadata
 
-"""
 from .core.processor import SedProcessor
 
-__version__ = "0.1.0"
+__version__ = importlib.metadata.version("sed-processor")
 __all__ = ["SedProcessor"]

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1,8 +1,0 @@
-"""This file contains code that performs several tests for the sed package
-"""
-from sed import __version__
-
-
-def test_version() -> None:
-    """This function tests for the version of the package"""
-    assert __version__ == "0.1.0"


### PR DESCRIPTION
Currently after importing sed, typing `sed.__version__` gives 0.1.0 because it's been hardcoded. This PR should solve the issue.