### PR TITLE
Flash test fixes

### DIFF
--- a/tests/data/loader/flash/config.yaml
+++ b/tests/data/loader/flash/config.yaml
@@ -49,7 +49,8 @@ dataframe:
   tof_ns_column: dldTime
   # dataframe column containing corrected time-of-flight data
   corrected_tof_column: "tm"
-
+  # the time stamp column
+  time_stamp_alias: timeStamp
   # time length of a base time-of-flight bin in seconds
   tof_binwidth: 2.0576131995767355E-11
   # binning parameter for time-of-flight data. 2**tof_binning bins per base bin

--- a/tests/loader/flash/conftest.py
+++ b/tests/loader/flash/conftest.py
@@ -23,7 +23,7 @@ def fixture_config_file():
     Returns:
         dict: The parsed configuration file.
     """
-    return parse_config(config_path)
+    return parse_config(config_path, folder_config={}, user_config={}, system_config={})
 
 
 @pytest.fixture(name="config_dataframe")
@@ -33,7 +33,9 @@ def fixture_config_file_dataframe():
     Returns:
         dict: The parsed configuration file.
     """
-    return parse_config(config_path)["dataframe"]
+    return parse_config(config_path, folder_config={}, user_config={}, system_config={})[
+        "dataframe"
+    ]
 
 
 @pytest.fixture(name="h5_file")

--- a/tests/loader/flash/conftest.py
+++ b/tests/loader/flash/conftest.py
@@ -17,7 +17,7 @@ H5_PATHS = [H5_PATH, "FLASH1_USER3_stream_2_run43879_file1_20230130T153807.1.h5"
 
 
 @pytest.fixture(name="config")
-def fixture_config_file():
+def fixture_config_file() -> dict:
     """Fixture providing a configuration file for FlashLoader tests.
 
     Returns:
@@ -27,7 +27,7 @@ def fixture_config_file():
 
 
 @pytest.fixture(name="config_dataframe")
-def fixture_config_file_dataframe():
+def fixture_config_file_dataframe() -> dict:
     """Fixture providing a configuration file for FlashLoader tests.
 
     Returns:
@@ -39,7 +39,7 @@ def fixture_config_file_dataframe():
 
 
 @pytest.fixture(name="h5_file")
-def fixture_h5_file():
+def fixture_h5_file() -> h5py.File:
     """Fixture providing an open h5 file.
 
     Returns:
@@ -49,7 +49,7 @@ def fixture_h5_file():
 
 
 @pytest.fixture(name="h5_file_copy")
-def fixture_h5_file_copy(tmp_path):
+def fixture_h5_file_copy(tmp_path: Path) -> h5py.File:
     """Fixture providing a copy of an open h5 file.
 
     Returns:
@@ -65,7 +65,7 @@ def fixture_h5_file_copy(tmp_path):
 
 
 @pytest.fixture(name="h5_paths")
-def fixture_h5_paths():
+def fixture_h5_paths() -> list[Path]:
     """Fixture providing a list of h5 file paths.
 
     Returns:

--- a/tests/loader/flash/test_dataframe_creator.py
+++ b/tests/loader/flash/test_dataframe_creator.py
@@ -1,4 +1,6 @@
 """Tests for DataFrameCreator functionality"""
+from pathlib import Path
+
 import h5py
 import numpy as np
 import pytest
@@ -10,7 +12,7 @@ from sed.loader.flash.dataframe import DataFrameCreator
 from sed.loader.flash.utils import get_channels
 
 
-def test_get_index_dataset_key(config_dataframe, h5_paths):
+def test_get_index_dataset_key(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of the index and dataset keys for a given channel."""
     config = config_dataframe
     channel = "dldPosX"
@@ -25,7 +27,7 @@ def test_get_index_dataset_key(config_dataframe, h5_paths):
         df.get_index_dataset_key(channel)
 
 
-def test_get_dataset_array(config_dataframe, h5_paths):
+def test_get_dataset_array(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of a h5py dataset for a given channel."""
 
     df = DataFrameCreator(config_dataframe, h5_paths[0])
@@ -50,7 +52,11 @@ def test_get_dataset_array(config_dataframe, h5_paths):
     assert dset.shape[1] == 500
 
 
-def test_empty_get_dataset_array(config_dataframe, h5_paths, h5_file_copy):
+def test_empty_get_dataset_array(
+    config_dataframe: dict,
+    h5_paths: list[Path],
+    h5_file_copy: h5py.File,
+) -> None:
     """Test the method when given an empty dataset."""
 
     channel = "gmdTunnel"
@@ -78,7 +84,7 @@ def test_empty_get_dataset_array(config_dataframe, h5_paths, h5_file_copy):
     assert dset_empty.shape[1] == 0
 
 
-def test_pulse_index(config_dataframe, h5_paths):
+def test_pulse_index(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of the pulse index for electron resolved data"""
 
     df = DataFrameCreator(config_dataframe, h5_paths[0])
@@ -113,7 +119,7 @@ def test_pulse_index(config_dataframe, h5_paths):
     assert index.is_monotonic_increasing
 
 
-def test_df_electron(config_dataframe, h5_paths):
+def test_df_electron(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of a pandas DataFrame for a channel of type [per electron]."""
     df = DataFrameCreator(config_dataframe, h5_paths[0])
 
@@ -152,7 +158,7 @@ def test_df_electron(config_dataframe, h5_paths):
     )
 
 
-def test_create_dataframe_per_pulse(config_dataframe, h5_paths):
+def test_create_dataframe_per_pulse(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of a pandas DataFrame for a channel of type [per pulse]."""
     df = DataFrameCreator(config_dataframe, h5_paths[0])
     result_df = df.df_pulse
@@ -182,7 +188,7 @@ def test_create_dataframe_per_pulse(config_dataframe, h5_paths):
     )
 
 
-def test_create_dataframe_per_train(config_dataframe, h5_paths):
+def test_create_dataframe_per_train(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of a pandas DataFrame for a channel of type [per train]."""
     df = DataFrameCreator(config_dataframe, h5_paths[0])
     result_df = df.df_train
@@ -235,7 +241,7 @@ def test_create_dataframe_per_train(config_dataframe, h5_paths):
     assert result_df.index.is_unique
 
 
-def test_group_name_not_in_h5(config_dataframe, h5_paths):
+def test_group_name_not_in_h5(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test ValueError when the group_name for a channel does not exist in the H5 file."""
     channel = "dldPosX"
     config = config_dataframe
@@ -246,7 +252,7 @@ def test_group_name_not_in_h5(config_dataframe, h5_paths):
         df.df_electron
 
 
-def test_create_dataframe_per_file(config_dataframe, h5_paths):
+def test_create_dataframe_per_file(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """Test the creation of pandas DataFrames for a given file."""
     df = DataFrameCreator(config_dataframe, h5_paths[0])
     result_df = df.df
@@ -258,7 +264,7 @@ def test_create_dataframe_per_file(config_dataframe, h5_paths):
     assert result_df.shape[0] == len(all_keys.unique())
 
 
-def test_get_index_dataset_key_error(config_dataframe, h5_paths):
+def test_get_index_dataset_key_error(config_dataframe: dict, h5_paths: list[Path]) -> None:
     """
     Test that a ValueError is raised when the dataset_key is missing for a channel in the config.
     """

--- a/tests/loader/flash/test_flash_loader.py
+++ b/tests/loader/flash/test_flash_loader.py
@@ -125,10 +125,11 @@ def test_save_read_parquet_flash(config: dict) -> None:
     assert new_files != final_files, "Files were not overwritten after the third call."
 
     # remove the parquet files
-    [data_parquet_dir.joinpath(file).unlink() for file in new_files]
+    for file in new_files:
+        data_parquet_dir.joinpath(file).unlink()
 
 
-def test_get_elapsed_time_fid(config: dict):
+def test_get_elapsed_time_fid(config: dict) -> None:
     """Test get_elapsed_time method of FlashLoader class"""
     # Create an instance of FlashLoader
     fl = FlashLoader(config=config)
@@ -172,7 +173,7 @@ def test_get_elapsed_time_fid(config: dict):
     assert "Timestamp metadata missing in file 0" in str(e.value)
 
 
-def test_get_elapsed_time_run(config: dict):
+def test_get_elapsed_time_run(config: dict) -> None:
     """Test get_elapsed_time method of FlashLoader class"""
     config_ = config.copy()
     data_parquet_dir = create_parquet_dir(config_, "get_elapsed_time_run")
@@ -201,7 +202,7 @@ def test_get_elapsed_time_run(config: dict):
         Path(fl.parquet_dir, "buffer").joinpath(file).unlink()
 
 
-def test_available_runs(monkeypatch: pytest.MonkeyPatch, config: dict):
+def test_available_runs(monkeypatch: pytest.MonkeyPatch, config: dict) -> None:
     """Test available_runs property of FlashLoader class"""
     # Create an instance of FlashLoader
     fl = FlashLoader(config=config)

--- a/tests/loader/flash/test_flash_metadata.py
+++ b/tests/loader/flash/test_flash_metadata.py
@@ -7,14 +7,14 @@ from sed.loader.flash.metadata import MetadataRetriever
 
 
 @pytest.fixture
-def mock_requests(requests_mock):
+def mock_requests(requests_mock) -> None:
     # Mocking the response for the dataset URL
     dataset_url = "https://example.com/Datasets/11013410%2F43878"
     requests_mock.get(dataset_url, json={"fake": "data"}, status_code=200)
 
 
 # Test cases for MetadataRetriever
-def test_get_metadata(mock_requests):  # noqa: ARG001
+def test_get_metadata(mock_requests: None) -> None:  # noqa: ARG001
     metadata_config = {
         "scicat_url": "https://example.com",
         "scicat_token": "fake_token",
@@ -25,7 +25,7 @@ def test_get_metadata(mock_requests):  # noqa: ARG001
     assert metadata == {"fake": "data"}
 
 
-def test_get_metadata_with_existing_metadata(mock_requests):  # noqa: ARG001
+def test_get_metadata_with_existing_metadata(mock_requests: None) -> None:  # noqa: ARG001
     metadata_config = {
         "scicat_url": "https://example.com",
         "scicat_token": "fake_token",
@@ -37,7 +37,7 @@ def test_get_metadata_with_existing_metadata(mock_requests):  # noqa: ARG001
     assert metadata == {"existing": "metadata", "fake": "data"}
 
 
-def test_get_metadata_per_run(mock_requests):  # noqa: ARG001
+def test_get_metadata_per_run(mock_requests: None) -> None:  # noqa: ARG001
     metadata_config = {
         "scicat_url": "https://example.com",
         "scicat_token": "fake_token",
@@ -48,7 +48,7 @@ def test_get_metadata_per_run(mock_requests):  # noqa: ARG001
     assert metadata == {"fake": "data"}
 
 
-def test_create_dataset_url_by_PID():
+def test_create_dataset_url_by_PID() -> None:
     metadata_config = {
         "scicat_url": "https://example.com",
         "scicat_token": "fake_token",

--- a/tests/loader/flash/test_utils.py
+++ b/tests/loader/flash/test_utils.py
@@ -1,4 +1,6 @@
 """Tests for utils functionality"""
+from pathlib import Path
+
 import pytest
 
 from .test_buffer_handler import create_parquet_dir
@@ -23,7 +25,7 @@ TRAIN_CHANNELS_EXTENDED = [
 INDEX_CHANNELS = ["trainId", "pulseId", "electronId"]
 
 
-def test_get_channels_by_format(config_dataframe):
+def test_get_channels_by_format(config_dataframe: dict) -> None:
     """
     Test function to verify the 'get_channels' method in FlashLoader class for
     retrieving channels based on formats and index inclusion.
@@ -78,7 +80,7 @@ def test_get_channels_by_format(config_dataframe):
     )
 
 
-def test_parquet_init_error():
+def test_parquet_init_error() -> None:
     """Test ParquetHandler initialization error"""
     with pytest.raises(ValueError) as e:
         _ = initialize_paths(filenames="test")
@@ -86,12 +88,12 @@ def test_parquet_init_error():
     assert "Please provide folder or paths." in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        _ = initialize_paths(folder="test")
+        _ = initialize_paths(folder=Path("test"))
 
     assert "With folder, please provide filenames." in str(e.value)
 
 
-def test_initialize_paths(config):
+def test_initialize_paths(config: dict) -> None:
     """Test ParquetHandler initialization"""
     folder = create_parquet_dir(config, "parquet_init")
 

--- a/tests/loader/test_loaders.py
+++ b/tests/loader/test_loaders.py
@@ -46,6 +46,9 @@ def get_loader_name_from_loader_object(loader: BaseLoader) -> str:
                     loader_name,
                     "config.yaml",
                 ),
+                folder_config={},
+                user_config={},
+                system_config={},
             ),
         )
         if loader.__name__ is gotten_loader.__name__:


### PR DESCRIPTION
Adds fixes for flash loader tests to run independently of local config files, and remove all intermediary parquet files.