### PR TITLE
Hextof tutorial missed out changes

### DIFF
--- a/sed/config/flash_example_config.yaml
+++ b/sed/config/flash_example_config.yaml
@@ -6,7 +6,7 @@ core:
   # the beamline where experiment took place
   beamline: pg2
   # the ID number of the beamtime
-  beamtime_id: 11013410
+  beamtime_id: 11019101
   # the year of the beamtime
   year: 2023
 
@@ -14,9 +14,9 @@ core:
   # provided, the loader will try to find the data based on year beamtimeID etc
   paths:
     # location of the raw data.
-    data_raw_dir: "tests/data/loader/flash/"
+    data_raw_dir: "/asap3/flash/gpfs/pg2/2023/data/11019101/raw/hdf/offline/fl1user3"
     # location of the intermediate parquet files.
-    data_parquet_dir: "tests/data/loader/flash/parquet"
+    data_parquet_dir: "Gd_W110/processed/"
 
 binning:
   # Since this will run on maxwell most probably, we have a lot of cores at our disposal

--- a/sed/config/flash_example_config.yaml
+++ b/sed/config/flash_example_config.yaml
@@ -14,9 +14,9 @@ core:
   # provided, the loader will try to find the data based on year beamtimeID etc
   paths:
     # location of the raw data.
-    data_raw_dir: "/asap3/flash/gpfs/pg2/2023/data/11019101/raw/hdf/offline/fl1user3"
+    data_raw_dir: ""
     # location of the intermediate parquet files.
-    data_parquet_dir: "Gd_W110/processed/"
+    data_parquet_dir: ""
 
 binning:
   # Since this will run on maxwell most probably, we have a lot of cores at our disposal

--- a/tutorial/4_hextof_workflow.ipynb
+++ b/tutorial/4_hextof_workflow.ipynb
@@ -113,33 +113,11 @@
     "config_override = {\n",
     "    \"core\": {\n",
     "        \"paths\": {\n",
-    "            \"data_raw_dir\": \"\",\n",
-    "            \"data_parquet_dir\": \"\"\n",
+    "            \"data_raw_dir\": path,\n",
+    "            \"data_parquet_dir\": buffer_path,\n",
     "        },\n",
     "    },\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If it is your beamtime, you can access both read the raw data and write to processed directory. For the public data, you can not write to processed directory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "config_override['core']['paths']['data_raw_dir'] = \"/asap3/flash/gpfs/pg2/2023/data/11019101/raw/hdf/offline/fl1user3\"\n",
-    "# If this will not work for you, please change it to a path where you have write access\n",
-    "config_override['core']['paths']['data_parquet_dir'] = \"/asap3/flash/gpfs/pg2/2023/data/11019101/processed\"\n",
-    "# So we write to user space\n",
-    "config_override['core']['paths']['data_parquet_dir'] = path + \"/processed\"\n",
-    "# If you aren't using maxwell and downloaded the data, use this path\n",
-    "config_override['core']['paths']['data_raw_dir'] = path"
    ]
   },
   {


### PR DESCRIPTION
Accidently reverted some changes that needed to be there.

Moreover, using the tutorial beamtime_id now because before it was set to the test data beamtime.

Additionally, the maxwell paths are provided instead of test data paths.