### PR TITLE
fix application of saved transformation, and add tests for this

### DIFF
--- a/sed/calibrator/momentum.py
+++ b/sed/calibrator/momentum.py
@@ -1732,7 +1732,7 @@ class MomentumCorrector:
                         self.spline_warp_estimate(verbose=verbose)
                     if self.transformations:
                         # Apply config pose adjustments
-                        self.pose_adjustment()
+                        self.pose_adjustment(apply=True)
                 else:
                     raise ValueError("No corrections or transformations defined!")
 

--- a/sed/core/processor.py
+++ b/sed/core/processor.py
@@ -711,6 +711,7 @@ class SedProcessor:
         if self.mc.slice_corrected is None:
             if self.mc.slice is None:
                 self.mc.slice = np.zeros(self._config["momentum"]["bins"][0:2])
+                self.mc.bin_ranges = self._config["momentum"]["ranges"]
             self.mc.slice_corrected = self.mc.slice
 
         if not use_correction:


### PR DESCRIPTION
Fix a problem with applying transformations from saved configuration without loading/generating a transformation slice, and add tests for this case.