### PR TITLE
Mpes process files from memory

### DIFF
--- a/sed/loader/mpes/loader.py
+++ b/sed/loader/mpes/loader.py
@@ -98,8 +98,6 @@ def hdf5_to_dataframe(
             search_pattern="Stream",
         )
 
-    test_proc.close()
-
     column_names = [alias_dict.get(group, group) for group in group_names]
 
     if time_stamps:
@@ -136,6 +134,8 @@ def hdf5_to_dataframe(
                 pass
 
     array_stack = da.concatenate(arrays, axis=1).T
+
+    test_proc.close()
 
     return ddf.from_dask_array(array_stack, columns=column_names)
 
@@ -188,8 +188,6 @@ def hdf5_to_timed_dataframe(
             search_pattern="Stream",
         )
 
-    test_proc.close()
-
     column_names = [alias_dict.get(group, group) for group in group_names]
 
     if time_stamps:
@@ -225,6 +223,8 @@ def hdf5_to_timed_dataframe(
                 pass
 
     array_stack = da.concatenate(arrays, axis=1).T
+
+    test_proc.close()
 
     return ddf.from_dask_array(array_stack, columns=column_names)
 
@@ -720,16 +720,16 @@ class MpesLoader(BaseLoader):
         Returns:
             Tuple[float, float]: A tuple containing the start and end time stamps
         """
-        h5file = load_h5_in_memory(self.files[0])
+        h5filename = self.files[0]
         timestamps = hdf5_to_array(
-            h5file,
+            h5filename=h5filename,
             group_names=self._config["dataframe"]["hdf5_groupnames"],
             time_stamps=True,
         )
         ts_from = timestamps[-1][1]
-        h5file = load_h5_in_memory(self.files[-1])
+        h5filename = self.files[-1]
         timestamps = hdf5_to_array(
-            h5file,
+            h5filename=h5filename,
             group_names=self._config["dataframe"]["hdf5_groupnames"],
             time_stamps=True,
         )

--- a/sed/loader/mpes/loader.py
+++ b/sed/loader/mpes/loader.py
@@ -319,7 +319,7 @@ def hdf5_to_array(
         except KeyError:
             # get the start time of the file from its modification date if the key
             # does not exist (old files)
-            start_time = os.path.getmtime(h5file.filename)  # convert to ms
+            start_time = os.path.getmtime(h5filename)  # convert to ms
             # the modification time points to the time when the file was finished, so we
             # need to correct for the time it took to write the file
             start_time -= len(ms_marker) / 1000
@@ -403,7 +403,7 @@ def hdf5_to_timed_array(
         except KeyError:
             # get the start time of the file from its modification date if the key
             # does not exist (old files)
-            start_time = os.path.getmtime(h5file.filename)  # convert to ms
+            start_time = os.path.getmtime(h5filename)  # convert to ms
             # the modification time points to the time when the file was finished, so we
             # need to correct for the time it took to write the file
             start_time -= len(ms_marker) / 1000


### PR DESCRIPTION
Processing directly from the files for mpes is rather slow if reading from a filesystem with poor seeking performance (e.g. hdd, network drives). To overcome this, we load all files completely into memory for each binning step, and then access them from there.