### PR TITLE
Fix for datasetmanager tests 

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -18,9 +18,6 @@ from sed.dataset import DatasetsManager as dm
 package_dir = os.path.dirname(find_spec("sed").origin)
 json_path = os.path.join(package_dir, "config/datasets.json")
 
-# cspell:ignore pytestmark xdist
-pytestmark = pytest.mark.xdist_group(name="dataset_tests")
-
 
 @pytest.fixture
 def zip_buffer():


### PR DESCRIPTION
Used group so that the tests would be serialized instead of parallel and used mock directories instead of the test folder